### PR TITLE
pass error message in channel

### DIFF
--- a/android/src/main/java/sq/flutter/tflite/TflitePlugin.java
+++ b/android/src/main/java/sq/flutter/tflite/TflitePlugin.java
@@ -57,7 +57,7 @@ public class TflitePlugin implements MethodCallHandler {
         result.success(res);
       }
       catch (Exception e) {
-        result.error("Failed to load model" , null, null);
+        result.error("Failed to load model" , e.getMessage(), e);
       }
     } if (call.method.equals("runModelOnImage")) {
       try {
@@ -65,7 +65,7 @@ public class TflitePlugin implements MethodCallHandler {
         result.success(res);
       }
       catch (Exception e) {
-        result.error("Failed to run model" , null, null);
+        result.error("Failed to run model" , e.getMessage(), e);
       }
     } if (call.method.equals("close")) {
       close();


### PR DESCRIPTION
Current failures on interacting with the API just return `null` which is not super useful. Passing in the error message can give context as to what went wrong.