### PR TITLE
Add an asynch option to offload the TfLite run from the UI thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,20 @@
 
 A Flutter plugin for accessing TensorFlow Lite API. Supports Classification and Object Detection on both iOS and Android.
 
+### Table of Contents
+
+- [Installation](#Installation)
+- [Usage](#Usage)
+    - [Image Classification](#Image%20Classification)
+    - [Object Detection](#Object%20Detection)
+      - [SSD MobileNet](#SSD%20MobileNet)
+      - [YOLO](#Tiny%20YOLOv2)
+    - [Pix2Pix](#Pix2Pix)
+    - [Deeplab](#Deeplab)
+- [Example](#Example)
+    - [Prediction in Static Images](#Prediction%20in%20Static%20Images)
+    - [Real-time Detection](#Real-time%20Detection)
+
 ### Breaking changes since 1.0.0:
 
 1. Updated to TensorFlow Lite API v1.12.0.
@@ -258,7 +272,7 @@ var recognitions = await Tflite.detectObjectOnFrame(
 );
 ```
 
-### pix2pix
+### Pix2Pix
 
 > Thanks to [RP](https://github.com/shaqian/flutter_tflite/pull/18) from [Green Appers](https://github.com/GreenAppers)
 
@@ -297,7 +311,7 @@ Output:
 - Run on image stream (video frame):
 
 ```dart
-var result = await unPix2PixOnFrame(
+var result = await runPix2PixOnFrame(
   bytesList: img.planes.map((plane) {return plane.bytes;}).toList(),// required
   imageHeight: img.height, // defaults to 1280
   imageWidth: img.width,   // defaults to 720
@@ -314,12 +328,61 @@ Output:
 }
 ```
 
-## Demo
+### Deeplab
 
-- Classification and object detection
+> Thanks to [RP](https://github.com/shaqian/flutter_tflite/pull/22) from [see--](https://github.com/see--) for Android implementation.
+
+- Output:
+  
+  The output of Deeplab inference is Uint8List type. Depending on the `outputType` used, the output is:
+
+  - (if outputType is png) byte array of a png image 
+
+  - (otherwise) byte array of r, g, b, a values of the pixels 
+
+- Run on image:
+
+```dart
+var result = await runSegmentationOnImage(
+  path: filepath,     // required
+  imageMean: 0.0,     // defaults to 0.0
+  imageStd: 255.0,    // defaults to 255.0
+  labelColors: [...], // defaults to https://github.com/shaqian/flutter_tflite/blob/master/lib/tflite.dart#L219
+  outputType: "png"   // defaults to "png"
+);
+```
+
+- Run on binary:
+
+```dart
+var result = await runSegmentationOnBinary(
+  binary: binary,     // required;
+  labelColors: [...], // defaults to https://github.com/shaqian/flutter_tflite/blob/master/lib/tflite.dart#L219
+  outputType: "png"   // defaults to "png"
+);
+```
+
+- Run on image stream (video frame):
+
+```dart
+var result = await runSegmentationOnFrame(
+  bytesList: img.planes.map((plane) {return plane.bytes;}).toList(),// required
+  imageHeight: img.height, // defaults to 1280
+  imageWidth: img.width,   // defaults to 720
+  imageMean: 127.5,        // defaults to 0.0
+  imageStd: 127.5,         // defaults to 255.0
+  rotation: 90,            // defaults to 90, Android only
+  labelColors: [...],      // defaults to https://github.com/shaqian/flutter_tflite/blob/master/lib/tflite.dart#L219
+  outputType: "png"        // defaults to "png"
+);
+```
+
+## Example
+
+### Prediction in Static Images
 
   Refer to the [example](https://github.com/shaqian/flutter_tflite/tree/master/example).
 
-- Real-time detection
+### Real-time detection
 
-  Refer to [flutter_realtime_detection](https://github.com/shaqian/flutter_realtime_detection).
+  Refer to [flutter_realtime_Detection](https://github.com/shaqian/flutter_realtime_detection).

--- a/android/src/main/java/sq/flutter/tflite/TflitePlugin.java
+++ b/android/src/main/java/sq/flutter/tflite/TflitePlugin.java
@@ -7,6 +7,7 @@ import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Matrix;
 import android.graphics.BitmapFactory;
+import android.os.AsyncTask;
 import android.os.SystemClock;
 import android.renderscript.Allocation;
 import android.renderscript.Element;
@@ -48,6 +49,7 @@ import java.util.Vector;
 public class TflitePlugin implements MethodCallHandler {
   private final Registrar mRegistrar;
   private Interpreter tfLite;
+  private boolean tfLiteBusy = false;
   private int inputSize = 0;
   private Vector<String> labels;
   float[][] labelProb;
@@ -74,48 +76,42 @@ public class TflitePlugin implements MethodCallHandler {
       }
     } else if (call.method.equals("runModelOnImage")) {
       try {
-        List<Map<String, Object>> res = runModelOnImage((HashMap) call.arguments);
-        result.success(res);
+        new RunModelOnImage((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("runModelOnBinary")) {
       try {
-        List<Map<String, Object>> res = runModelOnBinary((HashMap) call.arguments);
-        result.success(res);
+        new RunModelOnBinary((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("runModelOnFrame")) {
       try {
-        List<Map<String, Object>> res = runModelOnFrame((HashMap) call.arguments);
-        result.success(res);
+        new RunModelOnFrame((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("detectObjectOnImage")) {
       try {
-        List<Map<String, Object>> res = detectObjectOnImage((HashMap) call.arguments);
-        result.success(res);
+        detectObjectOnImage((HashMap) call.arguments, result);
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("detectObjectOnBinary")) {
       try {
-        List<Map<String, Object>> res = detectObjectOnBinary((HashMap) call.arguments);
-        result.success(res);
+        detectObjectOnBinary((HashMap) call.arguments, result);
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("detectObjectOnFrame")) {
       try {
-        List<Map<String, Object>> res = detectObjectOnFrame((HashMap) call.arguments);
-        result.success(res);
+        detectObjectOnFrame((HashMap) call.arguments, result);
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
@@ -124,48 +120,42 @@ public class TflitePlugin implements MethodCallHandler {
       close();
     } else if (call.method.equals("runPix2PixOnImage")) {
       try {
-        List<Map<String, Object>> res = runPix2PixOnImage((HashMap) call.arguments);
-        result.success(res);
+        new RunPix2PixOnImage((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("runPix2PixOnBinary")) {
       try {
-        List<Map<String, Object>> res = runPix2PixOnBinary((HashMap) call.arguments);
-        result.success(res);
+        new RunPix2PixOnBinary((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("runPix2PixOnFrame")) {
       try {
-        List<Map<String, Object>> res = runPix2PixOnFrame((HashMap) call.arguments);
-        result.success(res);
+        new RunPix2PixOnFrame((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("runSegmentationOnImage")) {
       try {
-        byte[] res = runSegmentationOnImage((HashMap) call.arguments);
-        result.success(res);
+        new RunSegmentationOnImage((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("runSegmentationOnBinary")) {
       try {
-        byte[] res = runSegmentationOnBinary((HashMap) call.arguments);
-        result.success(res);
+        new RunSegmentationOnBinary((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
       }
     } else if (call.method.equals("runSegmentationOnFrame")) {
       try {
-        byte[] res = runSegmentationOnFrame((HashMap) call.arguments);
-        result.success(res);
+        new RunSegmentationOnFrame((HashMap) call.arguments, result).executeTfliteTask();
       }
       catch (Exception e) {
         result.error("Failed to run model" , e.getMessage(), e);
@@ -370,60 +360,130 @@ public class TflitePlugin implements MethodCallHandler {
     return out;
   }
 
-  private List<Map<String, Object>> runModelOnImage(HashMap args) throws IOException {
-    String path = args.get("path").toString();
-    double mean = (double)(args.get("imageMean"));
-    float IMAGE_MEAN = (float)mean;
-    double std = (double)(args.get("imageStd"));
-    float IMAGE_STD = (float)std;
-    int NUM_RESULTS = (int)args.get("numResults");
-    double threshold = (double)args.get("threshold");
-    float THRESHOLD = (float)threshold;
+  private abstract class TfliteTask extends AsyncTask<Void, Void, Void> {
+    Result result;
+    boolean asynch;
 
-    long startTime = SystemClock.uptimeMillis();
-    tfLite.run(feedInputTensorImage(path, IMAGE_MEAN, IMAGE_STD), labelProb);
-    Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+    TfliteTask(HashMap args, Result result) {
+      if (tfLiteBusy) throw new RuntimeException("Interpreter busy");
+      else tfLiteBusy = true;
+      Object asynch = args.get("asynch");
+      this.asynch = asynch == null ? false : (boolean)asynch;
+      this.result = result;
+    }
 
-    return GetTopN(NUM_RESULTS, THRESHOLD);
+    abstract void runTflite();
+
+    abstract void onRunTfliteDone();
+
+    public void executeTfliteTask() {
+      if (asynch) execute();
+      else {
+        runTflite();
+        tfLiteBusy = false;
+        onRunTfliteDone();
+      }
+    }
+
+    protected Void doInBackground(Void... backgroundArguments) {
+      runTflite();
+      return null;
+    }
+
+    protected void onPostExecute(Void backgroundResult) {
+      tfLiteBusy = false;
+      onRunTfliteDone();
+    }
   }
 
-  private List<Map<String, Object>> runModelOnBinary(HashMap args) throws IOException {
-    byte[] binary = (byte[])args.get("binary");
-    int NUM_RESULTS = (int)args.get("numResults");
-    double threshold = (double)args.get("threshold");
-    float THRESHOLD = (float)threshold;
+  private class RunModelOnImage extends TfliteTask {
+    int NUM_RESULTS;
+    float THRESHOLD;
+    ByteBuffer input;
+    long startTime;
 
-    ByteBuffer imgData = ByteBuffer.wrap(binary);
-    tfLite.run(imgData, labelProb);
+    RunModelOnImage(HashMap args, Result result) throws IOException {
+      super(args, result);
 
-    return GetTopN(NUM_RESULTS, THRESHOLD);
+      String path = args.get("path").toString();
+      double mean = (double)(args.get("imageMean"));
+      float IMAGE_MEAN = (float)mean;
+      double std = (double)(args.get("imageStd"));
+      float IMAGE_STD = (float)std;
+      NUM_RESULTS = (int)args.get("numResults");
+      double threshold = (double)args.get("threshold");
+      THRESHOLD = (float)threshold;
+
+      startTime = SystemClock.uptimeMillis();
+      input = feedInputTensorImage(path, IMAGE_MEAN, IMAGE_STD);
+    }
+
+    protected void runTflite() { tfLite.run(input, labelProb); }
+
+    protected void onRunTfliteDone() {
+      Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+      result.success(GetTopN(NUM_RESULTS, THRESHOLD));
+    }
   }
 
-  private List<Map<String, Object>> runModelOnFrame(HashMap args) throws IOException {
-    List<byte[]> bytesList= (ArrayList)args.get("bytesList");
-    double mean = (double)(args.get("imageMean"));
-    float IMAGE_MEAN = (float)mean;
-    double std = (double)(args.get("imageStd"));
-    float IMAGE_STD = (float)std;
-    int imageHeight = (int)(args.get("imageHeight"));
-    int imageWidth = (int)(args.get("imageWidth"));
-    int rotation = (int)(args.get("rotation"));
-    int NUM_RESULTS = (int)args.get("numResults");
-    double threshold = (double)args.get("threshold");
-    float THRESHOLD = (float)threshold;
+  private class RunModelOnBinary extends TfliteTask {
+    int NUM_RESULTS;
+    float THRESHOLD;
+    ByteBuffer imgData;
 
-    long startTime = SystemClock.uptimeMillis();
+    RunModelOnBinary(HashMap args, Result result) throws IOException {
+      super(args, result);
 
-    ByteBuffer imgData = feedInputTensorFrame(bytesList, imageHeight, imageWidth, IMAGE_MEAN, IMAGE_STD, rotation);
+      byte[] binary = (byte[])args.get("binary");
+      NUM_RESULTS = (int)args.get("numResults");
+      double threshold = (double)args.get("threshold");
+      THRESHOLD = (float)threshold;
 
-    tfLite.run(imgData, labelProb);
+      imgData = ByteBuffer.wrap(binary);
+    }
 
-    Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+    protected void runTflite() { tfLite.run(imgData, labelProb); }
 
-    return GetTopN(NUM_RESULTS, THRESHOLD);
+    protected void onRunTfliteDone() {
+      result.success(GetTopN(NUM_RESULTS, THRESHOLD));
+    }
   }
 
-  private List<Map<String, Object>> detectObjectOnImage(HashMap args) throws IOException {
+  private class RunModelOnFrame extends TfliteTask {
+    int NUM_RESULTS;
+    float THRESHOLD;
+    long startTime;
+    ByteBuffer imgData;
+
+    RunModelOnFrame(HashMap args, Result result) throws IOException {
+      super(args, result);
+
+      List<byte[]> bytesList= (ArrayList)args.get("bytesList");
+      double mean = (double)(args.get("imageMean"));
+      float IMAGE_MEAN = (float)mean;
+      double std = (double)(args.get("imageStd"));
+      float IMAGE_STD = (float)std;
+      int imageHeight = (int)(args.get("imageHeight"));
+      int imageWidth = (int)(args.get("imageWidth"));
+      int rotation = (int)(args.get("rotation"));
+      NUM_RESULTS = (int)args.get("numResults");
+      double threshold = (double)args.get("threshold");
+      THRESHOLD = (float)threshold;
+
+      startTime = SystemClock.uptimeMillis();
+
+      imgData = feedInputTensorFrame(bytesList, imageHeight, imageWidth, IMAGE_MEAN, IMAGE_STD, rotation);
+    }
+
+    protected void runTflite() { tfLite.run(imgData, labelProb); }
+
+    protected void onRunTfliteDone() {
+      Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+      result.success(GetTopN(NUM_RESULTS, THRESHOLD));
+    }
+  }
+
+  void detectObjectOnImage(HashMap args, Result result) throws IOException {
     String path = args.get("path").toString();
     String model = args.get("model").toString();
     double mean = (double)(args.get("imageMean"));
@@ -440,13 +500,13 @@ public class TflitePlugin implements MethodCallHandler {
     ByteBuffer imgData = feedInputTensorImage(path, IMAGE_MEAN, IMAGE_STD);
 
     if (model.equals("SSDMobileNet")) {
-      return parseSSDMobileNet(imgData, NUM_RESULTS_PER_CLASS, THRESHOLD);
+      new RunSSDMobileNet(args, imgData, NUM_RESULTS_PER_CLASS, THRESHOLD, result).executeTfliteTask();
     } else {
-      return parseYOLO(imgData, BLOCK_SIZE, NUM_BOXES_PER_BLOCK, ANCHORS, THRESHOLD, NUM_RESULTS_PER_CLASS);
+      new RunYOLO(args, imgData, BLOCK_SIZE, NUM_BOXES_PER_BLOCK, ANCHORS, THRESHOLD, NUM_RESULTS_PER_CLASS, result).executeTfliteTask();
     }
   }
 
-  private List<Map<String, Object>> detectObjectOnBinary(HashMap args) throws IOException {
+  void detectObjectOnBinary(HashMap args, Result result) throws IOException {
     byte[] binary = (byte[])args.get("binary");
     String model = args.get("model").toString();
     double threshold = (double)args.get("threshold");
@@ -459,13 +519,13 @@ public class TflitePlugin implements MethodCallHandler {
     ByteBuffer imgData = ByteBuffer.wrap(binary);
 
     if (model.equals("SSDMobileNet")) {
-      return parseSSDMobileNet(imgData, NUM_RESULTS_PER_CLASS, THRESHOLD);
+      new RunSSDMobileNet(args, imgData, NUM_RESULTS_PER_CLASS, THRESHOLD, result).executeTfliteTask();
     } else {
-      return parseYOLO(imgData, BLOCK_SIZE, NUM_BOXES_PER_BLOCK, ANCHORS, THRESHOLD, NUM_RESULTS_PER_CLASS);
+      new RunYOLO(args, imgData, BLOCK_SIZE, NUM_BOXES_PER_BLOCK, ANCHORS, THRESHOLD, NUM_RESULTS_PER_CLASS, result).executeTfliteTask();
     }
   }
 
-  private List<Map<String, Object>> detectObjectOnFrame(HashMap args) throws IOException {
+  void detectObjectOnFrame(HashMap args, Result result) throws IOException {
     List<byte[]> bytesList= (ArrayList)args.get("bytesList");
     String model = args.get("model").toString();
     double mean = (double)(args.get("imageMean"));
@@ -486,320 +546,434 @@ public class TflitePlugin implements MethodCallHandler {
     ByteBuffer imgData = feedInputTensorFrame(bytesList, imageHeight, imageWidth, IMAGE_MEAN, IMAGE_STD, rotation);
 
     if (model.equals("SSDMobileNet")) {
-      return parseSSDMobileNet(imgData, NUM_RESULTS_PER_CLASS, THRESHOLD);
+      new RunSSDMobileNet(args, imgData, NUM_RESULTS_PER_CLASS, THRESHOLD, result).executeTfliteTask();
     } else {
-      return parseYOLO(imgData, BLOCK_SIZE, NUM_BOXES_PER_BLOCK, ANCHORS, THRESHOLD, NUM_RESULTS_PER_CLASS);
+      new RunYOLO(args, imgData, BLOCK_SIZE, NUM_BOXES_PER_BLOCK, ANCHORS, THRESHOLD, NUM_RESULTS_PER_CLASS, result).executeTfliteTask();
     }
   }
 
-  private List<Map<String, Object>> runPix2PixOnImage(HashMap args) throws IOException {
-    String path = args.get("path").toString();
-    double mean = (double)(args.get("imageMean"));
-    float IMAGE_MEAN = (float)mean;
-    double std = (double)(args.get("imageStd"));
-    float IMAGE_STD = (float)std;
+  private class RunPix2PixOnImage extends TfliteTask {
+    String path;
+    float IMAGE_MEAN, IMAGE_STD;
+    ByteBuffer input, output;
 
-    long startTime = SystemClock.uptimeMillis();
-    ByteBuffer input = feedInputTensorImage(path, IMAGE_MEAN, IMAGE_STD);
-    ByteBuffer output = ByteBuffer.allocateDirect(input.limit());
-    output.order(ByteOrder.nativeOrder());
-    if (input.limit() == 0) throw new RuntimeException("Unexpected input position, bad file?");
-    if (output.position() != 0) throw new RuntimeException("Unexpected output position");
-    tfLite.run(input, output);
-    if (output.position() != input.limit()) throw new RuntimeException("Mismatching input/output position");
+    RunPix2PixOnImage(HashMap args, Result result) throws IOException {
+      super(args, result);
+      path = args.get("path").toString();
+      double mean = (double)(args.get("imageMean"));
+      IMAGE_MEAN = (float)mean;
+      double std = (double)(args.get("imageStd"));
+      IMAGE_STD = (float)std;
 
-    output.flip();
-    Bitmap bitmapRaw = feedOutput(output, IMAGE_MEAN, IMAGE_STD);
-    String fileExt = path.substring(path.lastIndexOf('.')+1);
-    String outputFilename = path.substring(0, path.lastIndexOf('.')) + "_pix2pix." + fileExt;
-    try (FileOutputStream out = new FileOutputStream(outputFilename, false)) {
-      bitmapRaw.compress(Bitmap.CompressFormat.PNG, 100, out);
-    } catch (IOException e) {
-      e.printStackTrace();
-      outputFilename = "";
+      long startTime = SystemClock.uptimeMillis();
+      input = feedInputTensorImage(path, IMAGE_MEAN, IMAGE_STD);
+      output = ByteBuffer.allocateDirect(input.limit());
+      output.order(ByteOrder.nativeOrder());
+      if (input.limit() == 0) { result.error("Unexpected input position, bad file?", null, null); return; }
+      if (output.position() != 0) { result.error("Unexpected output position", null, null); return; }
     }
 
-    final ArrayList<Map<String, Object>> result = new ArrayList<>();
-    Map<String, Object> res = new HashMap<>();
-    res.put("filename", outputFilename);
-    result.add(res);
-    return result;
-  }
+    protected void runTflite() { tfLite.run(input, output); }
 
-  private List<Map<String, Object>> runPix2PixOnBinary(HashMap args) throws IOException {
-    byte[] binary = (byte[])args.get("binary");
+    protected void onRunTfliteDone() {
+      if (output.position() != input.limit()) { result.error("Mismatching input/output position", null, null); return; }
 
-    long startTime = SystemClock.uptimeMillis();
-    ByteBuffer input = ByteBuffer.wrap(binary);
-    ByteBuffer output = ByteBuffer.allocateDirect(input.limit());
-    output.order(ByteOrder.nativeOrder());
-
-    if (input.limit() == 0) throw new RuntimeException("Unexpected input position, bad file?");
-    if (output.position() != 0) throw new RuntimeException("Unexpected output position");
-    tfLite.run(input, output);
-    Log.v("time", "Generating took " + (SystemClock.uptimeMillis() - startTime));
-    if (output.position() != input.limit()) throw new RuntimeException("Mismatching input/output position");
-
-    final ArrayList<Map<String, Object>> result = new ArrayList<>();
-    Map<String, Object> res = new HashMap<>();
-    res.put("binary", output.array());
-    result.add(res);
-    return result;
-  }
-
-  private List<Map<String, Object>> runPix2PixOnFrame(HashMap args) throws IOException {
-    List<byte[]> bytesList= (ArrayList)args.get("bytesList");
-    double mean = (double)(args.get("imageMean"));
-    float IMAGE_MEAN = (float)mean;
-    double std = (double)(args.get("imageStd"));
-    float IMAGE_STD = (float)std;
-    int imageHeight = (int)(args.get("imageHeight"));
-    int imageWidth = (int)(args.get("imageWidth"));
-    int rotation = (int)(args.get("rotation"));
-
-    long startTime = SystemClock.uptimeMillis();
-    ByteBuffer input = feedInputTensorFrame(bytesList, imageHeight, imageWidth, IMAGE_MEAN, IMAGE_STD, rotation);
-    ByteBuffer output = ByteBuffer.allocateDirect(input.limit());
-    output.order(ByteOrder.nativeOrder());
-
-    if (input.limit() == 0) throw new RuntimeException("Unexpected input position, bad file?");
-    if (output.position() != 0) throw new RuntimeException("Unexpected output position");
-    tfLite.run(input, output);
-    Log.v("time", "Generating took " + (SystemClock.uptimeMillis() - startTime));
-    if (output.position() != input.limit()) throw new RuntimeException("Mismatching input/output position");
-
-    final ArrayList<Map<String, Object>> result = new ArrayList<>();
-    Map<String, Object> res = new HashMap<>();
-    res.put("binary", output.array());
-    result.add(res);
-    return result;
-  }
-
-  private List<Map<String, Object>> parseSSDMobileNet(ByteBuffer imgData, int numResultsPerClass, float threshold) {
-    int num = tfLite.getOutputTensor(0).shape()[1];
-    float[][][] outputLocations = new float[1][num][4];
-    float[][] outputClasses = new float[1][num];
-    float[][] outputScores = new float[1][num];
-    float[] numDetections = new float[1];
-
-    Object[] inputArray = {imgData};
-    Map<Integer, Object> outputMap = new HashMap<>();
-    outputMap.put(0, outputLocations);
-    outputMap.put(1, outputClasses);
-    outputMap.put(2, outputScores);
-    outputMap.put(3, numDetections);
-
-    long startTime = SystemClock.uptimeMillis();
-
-    tfLite.runForMultipleInputsOutputs(inputArray, outputMap);
-
-    Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
-
-    Map<String, Integer> counters = new HashMap<>();
-    final List<Map<String, Object>> results = new ArrayList<>();
-
-    for (int i = 0; i < numDetections[0]; ++i) {
-      if (outputScores[0][i] < threshold) continue;
-
-      String detectedClass = labels.get((int) outputClasses[0][i] + 1);
-
-      if (counters.get(detectedClass) == null) {
-        counters.put(detectedClass, 1);
-      } else {
-        int count = counters.get(detectedClass);
-        if (count >= numResultsPerClass) {
-          continue;
-        } else {
-          counters.put(detectedClass, count + 1);
-        }
+      output.flip();
+      Bitmap bitmapRaw = feedOutput(output, IMAGE_MEAN, IMAGE_STD);
+      String fileExt = path.substring(path.lastIndexOf('.')+1);
+      String outputFilename = path.substring(0, path.lastIndexOf('.')) + "_pix2pix." + fileExt;
+      try (FileOutputStream out = new FileOutputStream(outputFilename, false)) {
+        bitmapRaw.compress(Bitmap.CompressFormat.PNG, 100, out);
+      } catch (IOException e) {
+        e.printStackTrace();
+        outputFilename = "";
       }
 
-      Map<String, Object> rect = new HashMap<>();
-      float ymin = Math.max(0, outputLocations[0][i][0]);
-      float xmin = Math.max(0, outputLocations[0][i][1]);
-      float ymax = outputLocations[0][i][2];
-      float xmax = outputLocations[0][i][3];
-      rect.put("x", xmin);
-      rect.put("y", ymin);
-      rect.put("w", Math.min(1 - xmin, xmax - xmin));
-      rect.put("h", Math.min(1 - ymin, ymax - ymin));
-
-      Map<String, Object> result = new HashMap<>();
-      result.put("rect", rect);
-      result.put("confidenceInClass", outputScores[0][i]);
-      result.put("detectedClass", detectedClass);
-
-      results.add(result);
+      final ArrayList<Map<String, Object>> ret = new ArrayList<>();
+      Map<String, Object> res = new HashMap<>();
+      res.put("filename", outputFilename);
+      ret.add(res);
+      result.success(ret);
     }
-
-    return results;
   }
 
-  private List<Map<String, Object>> parseYOLO(ByteBuffer imgData,
-                                              int blockSize,
-                                              int numBoxesPerBlock,
-                                              List<Double> anchors,
-                                              float threshold,
-                                              int numResultsPerClass) {
-    long startTime = SystemClock.uptimeMillis();
+  private class RunPix2PixOnBinary extends TfliteTask {
+    long startTime;
+    ByteBuffer input, output;
 
-    Tensor tensor = tfLite.getInputTensor(0);
-    inputSize = tensor.shape()[1];
-    int gridSize = inputSize / blockSize;
-    int numClasses = labels.size();
-    final float[][][][] output = new float[1][gridSize][gridSize][(numClasses + 5) * numBoxesPerBlock];
-    tfLite.run(imgData, output);
+    RunPix2PixOnBinary(HashMap args, Result result) throws IOException {
+      super(args, result);
+      byte[] binary = (byte[])args.get("binary");
+      startTime = SystemClock.uptimeMillis();
+      input = ByteBuffer.wrap(binary);
+      output = ByteBuffer.allocateDirect(input.limit());
+      output.order(ByteOrder.nativeOrder());
 
-    Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+      if (input.limit() == 0) { result.error("Unexpected input position, bad file?", null, null); return; }
+      if (output.position() != 0) { result.error("Unexpected output position", null, null); return; }
+    }
 
-    PriorityQueue<Map<String, Object>> pq =
-        new PriorityQueue<>(
-            1,
-            new Comparator<Map<String, Object>>() {
-              @Override
-              public int compare(Map<String, Object> lhs, Map<String, Object> rhs) {
-                return Float.compare((float)rhs.get("confidenceInClass"), (float)lhs.get("confidenceInClass"));
-              }
-            });
+    protected void runTflite() { tfLite.run(input, output); }
 
-    for (int y = 0; y < gridSize; ++y) {
-      for (int x = 0; x < gridSize; ++x) {
-        for (int b = 0; b < numBoxesPerBlock; ++b) {
-          final int offset = (numClasses + 5) * b;
+    protected void onRunTfliteDone() {
+      Log.v("time", "Generating took " + (SystemClock.uptimeMillis() - startTime));
+      if (output.position() != input.limit()) { result.error("Mismatching input/output position", null, null); return; }
 
-          final float confidence = expit(output[0][y][x][offset + 4]);
+      final ArrayList<Map<String, Object>> ret = new ArrayList<>();
+      Map<String, Object> res = new HashMap<>();
+      res.put("binary", output.array());
+      ret.add(res);
+      result.success(ret);
+    }
+  }
 
-          final float[] classes = new float[numClasses];
-          for (int c = 0; c < numClasses; ++c) {
-            classes[c] = output[0][y][x][offset + 5 + c];
+  private class RunPix2PixOnFrame extends TfliteTask {
+    long startTime;
+    float IMAGE_MEAN, IMAGE_STD;
+    ByteBuffer input, output;
+
+    RunPix2PixOnFrame(HashMap args, Result result) throws IOException {
+      super(args, result);
+      List<byte[]> bytesList= (ArrayList)args.get("bytesList");
+      double mean = (double)(args.get("imageMean"));
+      IMAGE_MEAN = (float)mean;
+      double std = (double)(args.get("imageStd"));
+      IMAGE_STD = (float)std;
+      int imageHeight = (int)(args.get("imageHeight"));
+      int imageWidth = (int)(args.get("imageWidth"));
+      int rotation = (int)(args.get("rotation"));
+
+      startTime = SystemClock.uptimeMillis();
+      input = feedInputTensorFrame(bytesList, imageHeight, imageWidth, IMAGE_MEAN, IMAGE_STD, rotation);
+      output = ByteBuffer.allocateDirect(input.limit());
+      output.order(ByteOrder.nativeOrder());
+
+      if (input.limit() == 0) { result.error("Unexpected input position, bad file?", null, null); return; }
+      if (output.position() != 0) { result.error("Unexpected output position", null, null); return; }
+    }
+
+    protected void runTflite() { tfLite.run(input, output); }
+
+    protected void onRunTfliteDone() {
+      Log.v("time", "Generating took " + (SystemClock.uptimeMillis() - startTime));
+      if (output.position() != input.limit()) { result.error("Mismatching input/output position", null, null); return; }
+
+      final ArrayList<Map<String, Object>> ret = new ArrayList<>();
+      Map<String, Object> res = new HashMap<>();
+      res.put("binary", output.array());
+      ret.add(res);
+      result.success(ret);
+    }
+  }
+
+  private class RunSSDMobileNet extends TfliteTask {
+    int num;
+    int numResultsPerClass;
+    float threshold;
+    float[][][] outputLocations;
+    float[][] outputClasses;
+    float[][] outputScores;
+    float[] numDetections = new float[1];
+    Object[] inputArray;
+    Map<Integer, Object> outputMap = new HashMap<>();
+    long startTime;
+
+    RunSSDMobileNet(HashMap args, ByteBuffer imgData, int numResultsPerClass, float threshold, Result result) {
+      super(args, result);
+      this.num = tfLite.getOutputTensor(0).shape()[1];
+      this.numResultsPerClass = numResultsPerClass;
+      this.threshold = threshold;
+      this.outputLocations = new float[1][num][4];
+      this.outputClasses = new float[1][num];
+      this.outputScores = new float[1][num];
+      this.inputArray = new Object[] {imgData};
+
+      outputMap.put(0, outputLocations);
+      outputMap.put(1, outputClasses);
+      outputMap.put(2, outputScores);
+      outputMap.put(3, numDetections);
+
+      startTime = SystemClock.uptimeMillis();
+    }
+
+    protected void runTflite() { tfLite.runForMultipleInputsOutputs(inputArray, outputMap); }
+
+    protected void onRunTfliteDone() {
+      Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+
+      Map<String, Integer> counters = new HashMap<>();
+      final List<Map<String, Object>> results = new ArrayList<>();
+  
+      for (int i = 0; i < numDetections[0]; ++i) {
+        if (outputScores[0][i] < threshold) continue;
+
+        String detectedClass = labels.get((int) outputClasses[0][i] + 1);
+
+        if (counters.get(detectedClass) == null) {
+          counters.put(detectedClass, 1);
+        } else {
+          int count = counters.get(detectedClass);
+          if (count >= numResultsPerClass) {
+            continue;
+          } else {
+            counters.put(detectedClass, count + 1);
           }
-          softmax(classes);
+        }
 
-          int detectedClass = -1;
-          float maxClass = 0;
-          for (int c = 0; c < numClasses; ++c) {
-            if (classes[c] > maxClass) {
-              detectedClass = c;
-              maxClass = classes[c];
+        Map<String, Object> rect = new HashMap<>();
+        float ymin = Math.max(0, outputLocations[0][i][0]);
+        float xmin = Math.max(0, outputLocations[0][i][1]);
+        float ymax = outputLocations[0][i][2];
+        float xmax = outputLocations[0][i][3];
+        rect.put("x", xmin);
+        rect.put("y", ymin);
+        rect.put("w", Math.min(1 - xmin, xmax - xmin));
+        rect.put("h", Math.min(1 - ymin, ymax - ymin));
+
+        Map<String, Object> ret = new HashMap<>();
+        ret.put("rect", rect);
+        ret.put("confidenceInClass", outputScores[0][i]);
+        ret.put("detectedClass", detectedClass);
+
+        results.add(ret);
+      }
+
+      result.success(results);
+    }
+  }
+
+  private class RunYOLO extends TfliteTask {
+    ByteBuffer imgData;
+    int blockSize;
+    int numBoxesPerBlock;
+    List<Double> anchors;
+    float threshold;
+    int numResultsPerClass;
+    long startTime;
+    int gridSize;
+    int numClasses;
+    final float[][][][] output;
+
+    RunYOLO(HashMap args,
+            ByteBuffer imgData,
+            int blockSize,
+            int numBoxesPerBlock,
+            List<Double> anchors,
+            float threshold,
+            int numResultsPerClass,
+            Result result)
+    {
+      super(args, result);
+      this.imgData = imgData;
+      this.blockSize = blockSize;
+      this.numBoxesPerBlock = numBoxesPerBlock;
+      this.anchors = anchors;
+      this.threshold = threshold;
+      this.numResultsPerClass = numResultsPerClass;
+      this.startTime = SystemClock.uptimeMillis();
+
+      Tensor tensor = tfLite.getInputTensor(0);
+      inputSize = tensor.shape()[1];
+
+      this.gridSize = inputSize / blockSize;
+      this.numClasses = labels.size();
+      this.output = new float[1][gridSize][gridSize][(numClasses + 5) * numBoxesPerBlock];
+    }
+
+    protected void runTflite() { tfLite.run(imgData, output); }
+
+    protected void onRunTfliteDone() {
+      Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+
+      PriorityQueue<Map<String, Object>> pq =
+          new PriorityQueue<>(
+              1,
+              new Comparator<Map<String, Object>>() {
+                @Override
+                public int compare(Map<String, Object> lhs, Map<String, Object> rhs) {
+                  return Float.compare((float)rhs.get("confidenceInClass"), (float)lhs.get("confidenceInClass"));
+                }
+              });
+
+      for (int y = 0; y < gridSize; ++y) {
+        for (int x = 0; x < gridSize; ++x) {
+          for (int b = 0; b < numBoxesPerBlock; ++b) {
+            final int offset = (numClasses + 5) * b;
+
+            final float confidence = expit(output[0][y][x][offset + 4]);
+
+            final float[] classes = new float[numClasses];
+            for (int c = 0; c < numClasses; ++c) {
+              classes[c] = output[0][y][x][offset + 5 + c];
+            }
+            softmax(classes);
+
+            int detectedClass = -1;
+            float maxClass = 0;
+            for (int c = 0; c < numClasses; ++c) {
+              if (classes[c] > maxClass) {
+                detectedClass = c;
+                maxClass = classes[c];
+              }
+            }
+
+            final float confidenceInClass = maxClass * confidence;
+            if (confidenceInClass > threshold) {
+              final float xPos = (x + expit(output[0][y][x][offset + 0])) * blockSize;
+              final float yPos = (y + expit(output[0][y][x][offset + 1])) * blockSize;
+
+              final float w = (float) (Math.exp(output[0][y][x][offset + 2]) * anchors.get(2 * b + 0)) * blockSize;
+              final float h = (float) (Math.exp(output[0][y][x][offset + 3]) * anchors.get(2 * b + 1)) * blockSize;
+
+              final float xmin = Math.max(0, (xPos - w / 2) / inputSize);
+              final float ymin = Math.max(0, (yPos - h / 2) / inputSize);
+
+              Map<String, Object> rect = new HashMap<>();
+              rect.put("x", xmin);
+              rect.put("y", ymin);
+              rect.put("w", Math.min(1 - xmin, w / inputSize));
+              rect.put("h", Math.min(1 - ymin, h / inputSize));
+
+              Map<String, Object> ret = new HashMap<>();
+              ret.put("rect", rect);
+              ret.put("confidenceInClass", confidenceInClass);
+              ret.put("detectedClass", labels.get(detectedClass));
+
+              pq.add(ret);
             }
           }
+        }
+      }
 
-          final float confidenceInClass = maxClass * confidence;
-          if (confidenceInClass > threshold) {
-            final float xPos = (x + expit(output[0][y][x][offset + 0])) * blockSize;
-            final float yPos = (y + expit(output[0][y][x][offset + 1])) * blockSize;
+      Map<String, Integer> counters = new HashMap<>();
+      List<Map<String, Object>> results = new ArrayList<>();
 
-            final float w = (float) (Math.exp(output[0][y][x][offset + 2]) * anchors.get(2 * b + 0)) * blockSize;
-            final float h = (float) (Math.exp(output[0][y][x][offset + 3]) * anchors.get(2 * b + 1)) * blockSize;
+      for (int i = 0; i < pq.size(); ++i) {
+        Map<String, Object> ret = pq.poll();
+        String detectedClass = ret.get("detectedClass").toString();
 
-            final float xmin = Math.max(0, (xPos - w / 2) / inputSize);
-            final float ymin = Math.max(0, (yPos - h / 2) / inputSize);
-
-            Map<String, Object> rect = new HashMap<>();
-            rect.put("x", xmin);
-            rect.put("y", ymin);
-            rect.put("w", Math.min(1 - xmin, w / inputSize));
-            rect.put("h", Math.min(1 - ymin, h / inputSize));
-
-            Map<String, Object> result = new HashMap<>();
-            result.put("rect", rect);
-            result.put("confidenceInClass", confidenceInClass);
-            result.put("detectedClass", labels.get(detectedClass));
-
-            pq.add(result);
+        if (counters.get(detectedClass) == null) {
+          counters.put(detectedClass, 1);
+        } else {
+          int count = counters.get(detectedClass);
+          if (count >= numResultsPerClass) {
+            continue;
+          } else {
+            counters.put(detectedClass, count + 1);
           }
         }
+        results.add(ret);
       }
+      result.success(results);
+    }
+  }
+
+  private class RunSegmentationOnImage extends TfliteTask {
+    List<Long> labelColors;
+    String outputType;
+    long startTime;
+    ByteBuffer input, output;
+
+    RunSegmentationOnImage(HashMap args, Result result) throws IOException {
+      super(args, result);
+
+      String path = args.get("path").toString();
+      double mean = (double)(args.get("imageMean"));
+      float IMAGE_MEAN = (float)mean;
+      double std = (double)(args.get("imageStd"));
+      float IMAGE_STD = (float)std;
+
+      labelColors = (ArrayList)args.get("labelColors");
+      outputType = args.get("outputType").toString();
+
+      startTime = SystemClock.uptimeMillis();
+      input = feedInputTensorImage(path, IMAGE_MEAN, IMAGE_STD);
+      output = ByteBuffer.allocateDirect(tfLite.getOutputTensor(0).numBytes());
+      output.order(ByteOrder.nativeOrder());
     }
 
-    Map<String, Integer> counters = new HashMap<>();
-    List<Map<String, Object>> results = new ArrayList<>();
+    protected void runTflite() { tfLite.run(input, output); }
 
-    for (int i = 0; i < pq.size(); ++i) {
-      Map<String, Object> result = pq.poll();
-      String detectedClass = result.get("detectedClass").toString();
+    protected void onRunTfliteDone() {
+      Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
 
-      if (counters.get(detectedClass) == null) {
-        counters.put(detectedClass, 1);
-      } else {
-        int count = counters.get(detectedClass);
-        if (count >= numResultsPerClass) {
-          continue;
-        } else {
-          counters.put(detectedClass, count + 1);
-        }
-      }
-      results.add(result);
+      if (input.limit() == 0) result.error("Unexpected input position, bad file?", null, null);
+      if (output.position() != output.limit()) result.error("Unexpected output position", null, null);
+      output.flip();
+
+      result.success(fetchArgmax(output, labelColors, outputType));
     }
-    return results;
   }
 
-  private byte[] runSegmentationOnImage(HashMap args) throws IOException {
-    String path = args.get("path").toString();
-    double mean = (double)(args.get("imageMean"));
-    float IMAGE_MEAN = (float)mean;
-    double std = (double)(args.get("imageStd"));
-    float IMAGE_STD = (float)std;
-    List<Long> labelColors = (ArrayList)args.get("labelColors");
-    String outputType = args.get("outputType").toString();
+  private class RunSegmentationOnBinary extends TfliteTask {
+    List<Long> labelColors;
+    String outputType;
+    long startTime;
+    ByteBuffer input, output;
 
-    long startTime = SystemClock.uptimeMillis();
-    ByteBuffer input = feedInputTensorImage(path, IMAGE_MEAN, IMAGE_STD);
-    ByteBuffer output = ByteBuffer.allocateDirect(tfLite.getOutputTensor(0).numBytes());
-    output.order(ByteOrder.nativeOrder());
-    tfLite.run(input, output);
-    Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+    RunSegmentationOnBinary(HashMap args, Result result) throws IOException {
+      super(args, result);
 
-    if (input.limit() == 0) throw new RuntimeException("Unexpected input position, bad file?");
-    if (output.position() != output.limit()) throw new RuntimeException("Unexpected output position");
-    output.flip();
+      byte[] binary = (byte[])args.get("binary");
+      labelColors = (ArrayList)args.get("labelColors");
+      outputType = args.get("outputType").toString();
 
-    return fetchArgmax(output, labelColors, outputType);
+      startTime = SystemClock.uptimeMillis();
+      input = ByteBuffer.wrap(binary);
+      output = ByteBuffer.allocateDirect(tfLite.getOutputTensor(0).numBytes());
+      output.order(ByteOrder.nativeOrder());
+    }
+
+    protected void runTflite() { tfLite.run(input, output); }
+
+    protected void onRunTfliteDone() {
+      Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+
+      if (input.limit() == 0) result.error("Unexpected input position, bad file?", null, null);
+      if (output.position() != output.limit()) result.error("Unexpected output position", null, null);
+      output.flip();
+
+      result.success(fetchArgmax(output, labelColors, outputType));
+    }
   }
 
-  private byte[] runSegmentationOnBinary(HashMap args) throws IOException {
-    byte[] binary = (byte[])args.get("binary");
-    List<Long> labelColors = (ArrayList)args.get("labelColors");
-    String outputType = args.get("outputType").toString();
+  private class RunSegmentationOnFrame extends TfliteTask {
+    List<Long> labelColors;
+    String outputType;
+    long startTime;
+    ByteBuffer input, output;
 
-    long startTime = SystemClock.uptimeMillis();
-    ByteBuffer input = ByteBuffer.wrap(binary);
-    ByteBuffer output = ByteBuffer.allocateDirect(tfLite.getOutputTensor(0).numBytes());
-    output.order(ByteOrder.nativeOrder());
-    tfLite.run(input, output);
-    Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+    RunSegmentationOnFrame(HashMap args, Result result) throws IOException {
+      super(args, result);
 
-    if (input.limit() == 0) throw new RuntimeException("Unexpected input position, bad file?");
-    if (output.position() != output.limit()) throw new RuntimeException("Unexpected output position");
-    output.flip();
+      List<byte[]> bytesList= (ArrayList)args.get("bytesList");
+      double mean = (double)(args.get("imageMean"));
+      float IMAGE_MEAN = (float)mean;
+      double std = (double)(args.get("imageStd"));
+      float IMAGE_STD = (float)std;
+      int imageHeight = (int)(args.get("imageHeight"));
+      int imageWidth = (int)(args.get("imageWidth"));
+      int rotation = (int)(args.get("rotation"));
+      labelColors = (ArrayList)args.get("labelColors");
+      outputType = args.get("outputType").toString();
 
-    return fetchArgmax(output, labelColors, outputType);
-  }
+      startTime = SystemClock.uptimeMillis();
+      input = feedInputTensorFrame(bytesList, imageHeight, imageWidth, IMAGE_MEAN, IMAGE_STD, rotation);
+      output = ByteBuffer.allocateDirect(tfLite.getOutputTensor(0).numBytes());
+      output.order(ByteOrder.nativeOrder());
+    }
 
-  private byte[] runSegmentationOnFrame(HashMap args) throws IOException {
-    List<byte[]> bytesList= (ArrayList)args.get("bytesList");
-    double mean = (double)(args.get("imageMean"));
-    float IMAGE_MEAN = (float)mean;
-    double std = (double)(args.get("imageStd"));
-    float IMAGE_STD = (float)std;
-    int imageHeight = (int)(args.get("imageHeight"));
-    int imageWidth = (int)(args.get("imageWidth"));
-    int rotation = (int)(args.get("rotation"));
-    List<Long> labelColors = (ArrayList)args.get("labelColors");
-    String outputType = args.get("outputType").toString();
+    protected void runTflite() { tfLite.run(input, output); }
 
-    long startTime = SystemClock.uptimeMillis();
-    ByteBuffer input = feedInputTensorFrame(bytesList, imageHeight, imageWidth, IMAGE_MEAN, IMAGE_STD, rotation);
-    ByteBuffer output = ByteBuffer.allocateDirect(tfLite.getOutputTensor(0).numBytes());
-    output.order(ByteOrder.nativeOrder());
-    tfLite.run(input, output);
-    Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
+    protected void onRunTfliteDone() {
+      Log.v("time", "Inference took " + (SystemClock.uptimeMillis() - startTime));
 
-    if (input.limit() == 0) throw new RuntimeException("Unexpected input position, bad file?");
-    if (output.position() != output.limit()) throw new RuntimeException("Unexpected output position");
-    output.flip();
+      if (input.limit() == 0) result.error("Unexpected input position, bad file?", null, null);
+      if (output.position() != output.limit()) result.error("Unexpected output position", null, null);
+      output.flip();
 
-    return fetchArgmax(output, labelColors, outputType);
+      result.success(fetchArgmax(output, labelColors, outputType));
+    }
   }
 
   byte[] fetchArgmax(ByteBuffer output, List<Long> labelColors, String outputType) {

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -28,7 +28,7 @@ SPEC CHECKSUMS:
   Flutter: 9d0fac939486c9aba2809b7982dfdbb47a7b0296
   image_picker: ee00aab0487cedc80a304085219503cc6d0f2e22
   TensorFlowLite: e81aef029750aa46b42ad16553fa4cddd81498cc
-  tflite: da767354bf0b89bb6f20beccc32b5d86515b5830
+  tflite: f1966874335435ce6f49ebebf5e80fade09beb6b
 
 PODFILE CHECKSUM: 1e5af4103afd21ca5ead147d7b81d06f494f51a2
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -333,14 +333,11 @@ class _MyAppState extends State<MyApp> {
                   child: Text(yolo),
                   value: yolo,
                 ),
-              ];
-
-              if (Platform.isAndroid) {
-                menuEntries.add(const PopupMenuItem<String>(
+                const PopupMenuItem<String>(
                   child: Text(deeplab),
                   value: deeplab,
-                ));
-              }
+                )
+              ];
               return menuEntries;
             },
           )

--- a/ios/Classes/TflitePlugin.mm
+++ b/ios/Classes/TflitePlugin.mm
@@ -26,19 +26,21 @@
 
 #define LOG(x) std::cerr
 
+typedef void (^TfLiteStatusCallback)(TfLiteStatus);
 NSString* loadModel(NSObject<FlutterPluginRegistrar>* _registrar, NSDictionary* args);
-NSMutableArray* runModelOnImage(NSDictionary* args);
-NSMutableArray* runModelOnBinary(NSDictionary* args);
-NSMutableArray* runModelOnFrame(NSDictionary* args);
-NSMutableArray* detectObjectOnImage(NSDictionary* args);
-NSMutableArray* detectObjectOnBinary(NSDictionary* args);
-NSMutableArray* detectObjectOnFrame(NSDictionary* args);
-NSMutableArray* runPix2PixOnImage(NSDictionary* args);
-NSMutableArray* runPix2PixOnBinary(NSDictionary* args);
-NSMutableArray* runPix2PixOnFrame(NSDictionary* args);
-FlutterStandardTypedData* runSegmentationOnImage(NSDictionary* args);
-FlutterStandardTypedData* runSegmentationOnBinary(NSDictionary* args);
-FlutterStandardTypedData* runSegmentationOnFrame(NSDictionary* args);
+void runTfliteAsync(TfLiteStatusCallback cb);
+void runModelOnImage(NSDictionary* args, FlutterResult result);
+void runModelOnBinary(NSDictionary* args, FlutterResult result);
+void runModelOnFrame(NSDictionary* args, FlutterResult result);
+void detectObjectOnImage(NSDictionary* args, FlutterResult result);
+void detectObjectOnBinary(NSDictionary* args, FlutterResult result);
+void detectObjectOnFrame(NSDictionary* args, FlutterResult result);
+void runPix2PixOnImage(NSDictionary* args, FlutterResult result);
+void runPix2PixOnBinary(NSDictionary* args, FlutterResult result);
+void runPix2PixOnFrame(NSDictionary* args, FlutterResult result);
+void runSegmentationOnImage(NSDictionary* args, FlutterResult result);
+void runSegmentationOnBinary(NSDictionary* args, FlutterResult result);
+void runSegmentationOnFrame(NSDictionary* args, FlutterResult result);
 void close();
 
 @implementation TflitePlugin {
@@ -66,41 +68,29 @@ void close();
     NSString* load_result = loadModel(_registrar, call.arguments);
     result(load_result);
   } else if ([@"runModelOnImage" isEqualToString:call.method]) {
-    NSMutableArray* inference_result = runModelOnImage(call.arguments);
-    result(inference_result);
+    runModelOnImage(call.arguments, result);
   } else if ([@"runModelOnBinary" isEqualToString:call.method]) {
-    NSMutableArray* inference_result = runModelOnBinary(call.arguments);
-    result(inference_result);
+    runModelOnBinary(call.arguments, result);
   } else if ([@"runModelOnFrame" isEqualToString:call.method]) {
-    NSMutableArray* inference_result = runModelOnFrame(call.arguments);
-    result(inference_result);
+    runModelOnFrame(call.arguments, result);
   } else if ([@"detectObjectOnImage" isEqualToString:call.method]) {
-    NSMutableArray* inference_result = detectObjectOnImage(call.arguments);
-    result(inference_result);
+    detectObjectOnImage(call.arguments, result);
   } else if ([@"detectObjectOnBinary" isEqualToString:call.method]) {
-    NSMutableArray* inference_result = detectObjectOnBinary(call.arguments);
-    result(inference_result);
+    detectObjectOnBinary(call.arguments, result);
   } else if ([@"detectObjectOnFrame" isEqualToString:call.method]) {
-    NSMutableArray* inference_result = detectObjectOnFrame(call.arguments);
-    result(inference_result);
+    detectObjectOnFrame(call.arguments, result);
   } else if ([@"runPix2PixOnImage" isEqualToString:call.method]) {
-    NSMutableArray* generated_result = runPix2PixOnImage(call.arguments);
-    result(generated_result);
+    runPix2PixOnImage(call.arguments, result);
   } else if ([@"runPix2PixOnBinary" isEqualToString:call.method]) {
-    NSMutableArray* generated_result = runPix2PixOnBinary(call.arguments);
-    result(generated_result);
+    runPix2PixOnBinary(call.arguments, result);
   } else if ([@"runPix2PixOnFrame" isEqualToString:call.method]) {
-    NSMutableArray* generated_result = runPix2PixOnFrame(call.arguments);
-    result(generated_result);
+    runPix2PixOnFrame(call.arguments, result);
   } else if ([@"runSegmentationOnImage" isEqualToString:call.method]) {
-    FlutterStandardTypedData* generated_result = runSegmentationOnImage(call.arguments);
-    result(generated_result);
+    runSegmentationOnImage(call.arguments, result);
   } else if ([@"runSegmentationOnBinary" isEqualToString:call.method]) {
-    FlutterStandardTypedData* generated_result = runSegmentationOnBinary(call.arguments);
-    result(generated_result);
+    runSegmentationOnBinary(call.arguments, result);
   } else if ([@"runSegmentationOnFrame" isEqualToString:call.method]) {
-    FlutterStandardTypedData* generated_result = runSegmentationOnFrame(call.arguments);
-    result(generated_result);
+    runSegmentationOnFrame(call.arguments, result);
   } else if ([@"close" isEqualToString:call.method]) {
     close();
   } else {
@@ -113,6 +103,7 @@ void close();
 std::vector<std::string> labels;
 std::unique_ptr<tflite::FlatBufferModel> model;
 std::unique_ptr<tflite::Interpreter> interpreter;
+bool interpreter_busy = false;
 
 static void LoadLabels(NSString* labels_path,
                        std::vector<std::string>* label_strings) {
@@ -160,6 +151,17 @@ NSString* loadModel(NSObject<FlutterPluginRegistrar>* _registrar, NSDictionary* 
     interpreter->SetNumThreads(num_threads);
   }
   return @"success";
+}
+
+void runTfliteAsync(TfLiteStatusCallback cb) {
+  interpreter_busy = true;
+  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+    TfLiteStatus status = interpreter->Invoke();
+    dispatch_async(dispatch_get_main_queue(), ^(void){
+      interpreter_busy = false;
+      cb(status);
+    });
+  });
 }
 
 NSMutableData *feedOutputTensor(int outputChannelsIn, float mean, float std, bool convertToUint8,
@@ -335,67 +337,70 @@ NSMutableArray* GetTopN(const float* prediction, const unsigned long prediction_
   return predictions;
 }
 
-NSMutableArray* runModelOnImage(NSDictionary* args) {
+void runModelOnImage(NSDictionary* args, FlutterResult result) {
   const NSString* image_path = args[@"path"];
   const float input_mean = [args[@"imageMean"] floatValue];
   const float input_std = [args[@"imageStd"] floatValue];
   
   NSMutableArray* empty = [@[] mutableCopy];
   
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
   
   int input_size;
   feedInputTensorImage(image_path, input_mean, input_std, &input_size);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
-  }
-  
-  float* output = interpreter->typed_output_tensor<float>(0);
-  
-  if (output == NULL)
-    return empty;
-  
-  const unsigned long output_size = labels.size();
-  const int num_results = [args[@"numResults"] intValue];
-  const float threshold = [args[@"threshold"] floatValue];
-  return GetTopN(output, output_size, num_results, threshold);
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    float* output = interpreter->typed_output_tensor<float>(0);
+
+    if (output == NULL)
+      return result(empty);
+
+    const unsigned long output_size = labels.size();
+    const int num_results = [args[@"numResults"] intValue];
+    const float threshold = [args[@"threshold"] floatValue];
+    return result(GetTopN(output, output_size, num_results, threshold));
+  });
 }
 
-NSMutableArray* runModelOnBinary(NSDictionary* args) {
+void runModelOnBinary(NSDictionary* args, FlutterResult result) {
   const FlutterStandardTypedData* typedData = args[@"binary"];
   NSMutableArray* empty = [@[] mutableCopy];
   
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
 
   int input_size;
   feedInputTensorBinary(typedData, &input_size);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
-  }
-  
-  float* output = interpreter->typed_output_tensor<float>(0);
-  
-  if (output == NULL)
-    return empty;
-  
-  const unsigned long output_size = labels.size();
-  const int num_results = [args[@"numResults"] intValue];
-  const float threshold = [args[@"threshold"] floatValue];
-  return GetTopN(output, output_size, num_results, threshold);
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    float* output = interpreter->typed_output_tensor<float>(0);
+
+    if (output == NULL)
+      return result(empty);
+
+    const unsigned long output_size = labels.size();
+    const int num_results = [args[@"numResults"] intValue];
+    const float threshold = [args[@"threshold"] floatValue];
+    return result(GetTopN(output, output_size, num_results, threshold));
+  });
 }
 
-
-NSMutableArray* runModelOnFrame(NSDictionary* args) {
+void runModelOnFrame(NSDictionary* args, FlutterResult result) {
   const FlutterStandardTypedData* typedData = args[@"bytesList"][0];
   const int image_height = [args[@"imageHeight"] intValue];
   const int image_width = [args[@"imageWidth"] intValue];
@@ -403,29 +408,31 @@ NSMutableArray* runModelOnFrame(NSDictionary* args) {
   const float input_std = [args[@"imageStd"] floatValue];
   NSMutableArray* empty = [@[] mutableCopy];
   
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
   
   int input_size;
   int image_channels = 4;
   feedInputTensorFrame(typedData, &input_size, image_height, image_width, image_channels, input_mean, input_std);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
-  }
-  
-  float* output = interpreter->typed_output_tensor<float>(0);
-  
-  if (output == NULL)
-    return empty;
-  
-  const unsigned long output_size = labels.size();
-  const int num_results = [args[@"numResults"] intValue];
-  const float threshold = [args[@"threshold"] floatValue];
-  return GetTopN(output, output_size, num_results, threshold);
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    float* output = interpreter->typed_output_tensor<float>(0);
+
+    if (output == NULL)
+      return result(empty);
+
+    const unsigned long output_size = labels.size();
+    const int num_results = [args[@"numResults"] intValue];
+    const float threshold = [args[@"threshold"] floatValue];
+    return result(GetTopN(output, output_size, num_results, threshold));
+  });
 }
 
 NSMutableArray* parseSSDMobileNet(float threshold, int num_results_per_class) {
@@ -583,7 +590,7 @@ NSMutableArray* parseYOLO(int num_classes, const NSArray* anchors, int block_siz
   return results;
 }
 
-NSMutableArray* detectObjectOnImage(NSDictionary* args) {
+void detectObjectOnImage(NSDictionary* args, FlutterResult result) {
   const NSString* image_path = args[@"path"];
   const NSString* model = args[@"model"];
   const float threshold = [args[@"threshold"] floatValue];
@@ -597,27 +604,29 @@ NSMutableArray* detectObjectOnImage(NSDictionary* args) {
   
   NSMutableArray* empty = [@[] mutableCopy];
   
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
   
   int input_size;
   feedInputTensorImage(image_path, input_mean, input_std, &input_size);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
-  }
-  
-  if ([model isEqual: @"SSDMobileNet"])
-    return parseSSDMobileNet(threshold, num_results_per_class);
-  else
-    return parseYOLO((int)(labels.size() - 1), anchors, block_size, num_boxes_per_block, num_results_per_class,
-                     threshold, input_size);
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    if ([model isEqual: @"SSDMobileNet"])
+      return result(parseSSDMobileNet(threshold, num_results_per_class));
+    else
+      return result(parseYOLO((int)(labels.size() - 1), anchors, block_size, num_boxes_per_block, num_results_per_class,
+                              threshold, input_size));
+  });
 }
 
-NSMutableArray* detectObjectOnBinary(NSDictionary* args) {
+void detectObjectOnBinary(NSDictionary* args, FlutterResult result) {
   const FlutterStandardTypedData* typedData = args[@"binary"];
   const NSString* model = args[@"model"];
   const float threshold = [args[@"threshold"] floatValue];
@@ -629,27 +638,29 @@ NSMutableArray* detectObjectOnBinary(NSDictionary* args) {
   
   NSMutableArray* empty = [@[] mutableCopy];
   
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
   
   int input_size;
   feedInputTensorBinary(typedData, &input_size);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
-  }
-  
-  if ([model isEqual: @"SSDMobileNet"])
-    return parseSSDMobileNet(threshold, num_results_per_class);
-  else
-    return parseYOLO((int)(labels.size() - 1), anchors, block_size, num_boxes_per_block, num_results_per_class,
-                     threshold, input_size);
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    if ([model isEqual: @"SSDMobileNet"])
+      return result(parseSSDMobileNet(threshold, num_results_per_class));
+    else
+      return result(parseYOLO((int)(labels.size() - 1), anchors, block_size, num_boxes_per_block, num_results_per_class,
+                              threshold, input_size));
+  });
 }
 
-NSMutableArray* detectObjectOnFrame(NSDictionary* args) {
+void detectObjectOnFrame(NSDictionary* args, FlutterResult result) {
   const FlutterStandardTypedData* typedData = args[@"bytesList"][0];
   const NSString* model = args[@"model"];
   const int image_height = [args[@"imageHeight"] intValue];
@@ -665,96 +676,102 @@ NSMutableArray* detectObjectOnFrame(NSDictionary* args) {
   
   NSMutableArray* empty = [@[] mutableCopy];
   
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
   
   int input_size;
   int image_channels = 4;
   feedInputTensorFrame(typedData, &input_size, image_height, image_width, image_channels, input_mean, input_std);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
-  }
-  
-  if ([model isEqual: @"SSDMobileNet"])
-    return parseSSDMobileNet(threshold, num_results_per_class);
-  else
-    return parseYOLO((int)(labels.size() - 1), anchors, block_size, num_boxes_per_block, num_results_per_class,
-                     threshold, input_size);
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    if ([model isEqual: @"SSDMobileNet"])
+      return result(parseSSDMobileNet(threshold, num_results_per_class));
+    else
+      return result(parseYOLO((int)(labels.size() - 1), anchors, block_size, num_boxes_per_block, num_results_per_class,
+                              threshold, input_size));
+  });
 }
 
-NSMutableArray* runPix2PixOnImage(NSDictionary* args) {
+void runPix2PixOnImage(NSDictionary* args, FlutterResult result) {
   const NSString* image_path = args[@"path"];
   const float input_mean = [args[@"imageMean"] floatValue];
   const float input_std = [args[@"imageStd"] floatValue];
 
   NSMutableArray* empty = [@[] mutableCopy];
 
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
 
   int input_size;
   feedInputTensorImage(image_path, input_mean, input_std, &input_size);
 
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    int width = 0, height = 0;
+    NSMutableData* output = feedOutputTensor(4, input_mean, input_std, true, &width, &height);
+    if (output == NULL)
+      return result(empty);
+
+    NSString *ext = image_path.pathExtension, *out_path = image_path.stringByDeletingPathExtension;
+    out_path = [NSString stringWithFormat:@"%@_pix2pix.%@", out_path, ext];
+    if (SaveImageToFile(output, [out_path UTF8String], width, height, 1)) {
+      NSMutableArray* results = [NSMutableArray array];
+      NSMutableDictionary* res = [NSMutableDictionary dictionary];
+      [res setObject:out_path forKey:@"filename"];
+      [results addObject:res];
+      return result(results);
+    }
+
+    return result(empty);
+  });
+}
+
+void runPix2PixOnBinary(NSDictionary* args, FlutterResult result) {
+  const FlutterStandardTypedData* typedData = args[@"binary"];
+  NSMutableArray* empty = [@[] mutableCopy];
+
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
 
-  int width = 0, height = 0;
-  NSMutableData* output = feedOutputTensor(4, input_mean, input_std, true, &width, &height);
-  if (output == NULL)
-    return empty;
+  int input_size;
+  feedInputTensorBinary(typedData, &input_size);
 
-  NSString *ext = image_path.pathExtension, *out_path = image_path.stringByDeletingPathExtension;
-  out_path = [NSString stringWithFormat:@"%@_pix2pix.%@", out_path, ext];
-  if (SaveImageToFile(output, [out_path UTF8String], width, height, 1)) {
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    int width = 0, height = 0;
+    NSMutableData* output = feedOutputTensor(0, 0, 1, false, &width, &height);
+    if (output == NULL)
+      return result(empty);
+
+    FlutterStandardTypedData* ret = [FlutterStandardTypedData typedDataWithBytes: output];
     NSMutableArray* results = [NSMutableArray array];
     NSMutableDictionary* res = [NSMutableDictionary dictionary];
-    [res setObject:out_path forKey:@"filename"];
+    [res setObject:ret forKey:@"binary"];
     [results addObject:res];
-    return results;
-  }
-
-  return empty;
+    return result(results);
+  });
 }
 
-NSMutableArray* runPix2PixOnBinary(NSDictionary* args) {
-  const FlutterStandardTypedData* typedData = args[@"binary"];
-  NSMutableArray* empty = [@[] mutableCopy];
-
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
-  }
-
-  int input_size;
-  feedInputTensorBinary(typedData, &input_size);
-
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
-  }
-
-  int width = 0, height = 0;
-  NSMutableData* output = feedOutputTensor(0, 0, 1, false, &width, &height);
-  if (output == NULL)
-    return empty;
-
-  FlutterStandardTypedData* ret = [FlutterStandardTypedData typedDataWithBytes: output];
-  NSMutableArray* results = [NSMutableArray array];
-  NSMutableDictionary* res = [NSMutableDictionary dictionary];
-  [res setObject:ret forKey:@"binary"];
-  [results addObject:res];
-  return results;
-}
-
-NSMutableArray* runPix2PixOnFrame(NSDictionary* args) {
+void runPix2PixOnFrame(NSDictionary* args, FlutterResult result) {
   const FlutterStandardTypedData* typedData = args[@"bytesList"][0];
   const int image_height = [args[@"imageHeight"] intValue];
   const int image_width = [args[@"imageWidth"] intValue];
@@ -762,31 +779,33 @@ NSMutableArray* runPix2PixOnFrame(NSDictionary* args) {
   const float input_std = [args[@"imageStd"] floatValue];
   NSMutableArray* empty = [@[] mutableCopy];
 
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
-    return empty;
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
+    return result(empty);
   }
 
   int input_size;
   int image_channels = 4;
   feedInputTensorFrame(typedData, &input_size, image_height, image_width, image_channels, input_mean, input_std);
 
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return empty;
-  }
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
 
-  int width = 0, height = 0;
-  NSMutableData* output = feedOutputTensor(0, 0, 1, false, &width, &height);
-  if (output == NULL)
-    return empty;
+    int width = 0, height = 0;
+    NSMutableData* output = feedOutputTensor(0, 0, 1, false, &width, &height);
+    if (output == NULL)
+      return result(empty);
 
-  FlutterStandardTypedData* ret = [FlutterStandardTypedData typedDataWithBytes: output];
-  NSMutableArray* results = [NSMutableArray array];
-  NSMutableDictionary* res = [NSMutableDictionary dictionary];
-  [res setObject:ret forKey:@"binary"];
-  [results addObject:res];
-  return results;
+    FlutterStandardTypedData* ret = [FlutterStandardTypedData typedDataWithBytes: output];
+    NSMutableArray* results = [NSMutableArray array];
+    NSMutableDictionary* res = [NSMutableDictionary dictionary];
+    [res setObject:ret forKey:@"binary"];
+    [results addObject:res];
+    return result(results);
+  });
 }
 
 void setPixel(char* rgba, int index, long color) {
@@ -866,55 +885,61 @@ NSData* fetchArgmax(const NSArray* labelColors, const NSString* outputType) {
   }
 }
 
-FlutterStandardTypedData* runSegmentationOnImage(NSDictionary* args) {
+void runSegmentationOnImage(NSDictionary* args, FlutterResult result) {
   const NSString* image_path = args[@"path"];
   const float input_mean = [args[@"imageMean"] floatValue];
   const float input_std = [args[@"imageStd"] floatValue];
   const NSArray* labelColors = args[@"labelColors"];
   const NSString* outputType = args[@"outputType"];
+  NSMutableArray* empty = [@[] mutableCopy];
   
   if (!interpreter) {
     NSLog(@"Failed to construct interpreter.");
-    return nil;
+    return result(empty);
   }
   
   int input_size;
   feedInputTensorImage(image_path, input_mean, input_std, &input_size);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return nil;
-  }
-  
-  NSData* output = fetchArgmax(labelColors, outputType);
-  FlutterStandardTypedData* result = [FlutterStandardTypedData typedDataWithBytes: output];
-  return result;
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    NSData* output = fetchArgmax(labelColors, outputType);
+    FlutterStandardTypedData* ret = [FlutterStandardTypedData typedDataWithBytes: output];
+    return result(ret);
+  });
 }
 
-FlutterStandardTypedData* runSegmentationOnBinary(NSDictionary* args) {
+void runSegmentationOnBinary(NSDictionary* args, FlutterResult result) {
   const FlutterStandardTypedData* typedData = args[@"binary"];
   const NSArray* labelColors = args[@"labelColors"];
   const NSString* outputType = args[@"outputType"];
+  NSMutableArray* empty = [@[] mutableCopy];
   
   if (!interpreter) {
     NSLog(@"Failed to construct interpreter.");
-    return nil;
+    return result(empty);
   }
   
   int input_size;
   feedInputTensorBinary(typedData, &input_size);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return nil;
-  }
-  
-  NSData* output = fetchArgmax(labelColors, outputType);
-  FlutterStandardTypedData* result = [FlutterStandardTypedData typedDataWithBytes: output];
-  return result;
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    NSData* output = fetchArgmax(labelColors, outputType);
+    FlutterStandardTypedData* ret = [FlutterStandardTypedData typedDataWithBytes: output];
+    return result(ret);
+  });
 }
 
-FlutterStandardTypedData* runSegmentationOnFrame(NSDictionary* args) {
+void runSegmentationOnFrame(NSDictionary* args, FlutterResult result) {
   const FlutterStandardTypedData* typedData = args[@"bytesList"][0];
   const int image_height = [args[@"imageHeight"] intValue];
   const int image_width = [args[@"imageWidth"] intValue];
@@ -922,24 +947,27 @@ FlutterStandardTypedData* runSegmentationOnFrame(NSDictionary* args) {
   const float input_std = [args[@"imageStd"] floatValue];
   const NSArray* labelColors = args[@"labelColors"];
   const NSString* outputType = args[@"outputType"];
+  NSMutableArray* empty = [@[] mutableCopy];
   
   if (!interpreter) {
     NSLog(@"Failed to construct interpreter.");
-    return nil;
+    return result(empty);
   }
   
   int input_size;
   int image_channels = 4;
   feedInputTensorFrame(typedData, &input_size, image_height, image_width, image_channels, input_mean, input_std);
   
-  if (interpreter->Invoke() != kTfLiteOk) {
-    NSLog(@"Failed to invoke!");
-    return nil;
-  }
-  
-  NSData* output = fetchArgmax(labelColors, outputType);
-  FlutterStandardTypedData* result = [FlutterStandardTypedData typedDataWithBytes: output];
-  return result;
+  runTfliteAsync(^(TfLiteStatus status) {
+    if (status != kTfLiteOk) {
+      NSLog(@"Failed to invoke!");
+      return result(empty);
+    }
+
+    NSData* output = fetchArgmax(labelColors, outputType);
+    FlutterStandardTypedData* ret = [FlutterStandardTypedData typedDataWithBytes: output];
+    return result(ret);
+  });
 }
 
 void close() {

--- a/ios/Classes/TflitePlugin.mm
+++ b/ios/Classes/TflitePlugin.mm
@@ -28,7 +28,7 @@
 
 typedef void (^TfLiteStatusCallback)(TfLiteStatus);
 NSString* loadModel(NSObject<FlutterPluginRegistrar>* _registrar, NSDictionary* args);
-void runTfliteAsync(TfLiteStatusCallback cb);
+void runTflite(NSDictionary* args, TfLiteStatusCallback cb);
 void runModelOnImage(NSDictionary* args, FlutterResult result);
 void runModelOnBinary(NSDictionary* args, FlutterResult result);
 void runModelOnFrame(NSDictionary* args, FlutterResult result);
@@ -153,15 +153,21 @@ NSString* loadModel(NSObject<FlutterPluginRegistrar>* _registrar, NSDictionary* 
   return @"success";
 }
 
-void runTfliteAsync(TfLiteStatusCallback cb) {
-  interpreter_busy = true;
-  dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
-    TfLiteStatus status = interpreter->Invoke();
-    dispatch_async(dispatch_get_main_queue(), ^(void){
-      interpreter_busy = false;
-      cb(status);
+void runTflite(NSDictionary* args, TfLiteStatusCallback cb) {
+  const bool asynch = [args[@"asynch"] boolValue];
+  if (asynch) {
+    interpreter_busy = true;
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+      TfLiteStatus status = interpreter->Invoke();
+      dispatch_async(dispatch_get_main_queue(), ^(void){
+        interpreter_busy = false;
+        cb(status);
+      });
     });
-  });
+  } else {
+    TfLiteStatus status = interpreter->Invoke();
+    cb(status);
+  }
 }
 
 NSMutableData *feedOutputTensor(int outputChannelsIn, float mean, float std, bool convertToUint8,
@@ -352,7 +358,7 @@ void runModelOnImage(NSDictionary* args, FlutterResult result) {
   int input_size;
   feedInputTensorImage(image_path, input_mean, input_std, &input_size);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -382,7 +388,7 @@ void runModelOnBinary(NSDictionary* args, FlutterResult result) {
   int input_size;
   feedInputTensorBinary(typedData, &input_size);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -417,7 +423,7 @@ void runModelOnFrame(NSDictionary* args, FlutterResult result) {
   int image_channels = 4;
   feedInputTensorFrame(typedData, &input_size, image_height, image_width, image_channels, input_mean, input_std);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -612,7 +618,7 @@ void detectObjectOnImage(NSDictionary* args, FlutterResult result) {
   int input_size;
   feedInputTensorImage(image_path, input_mean, input_std, &input_size);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -646,7 +652,7 @@ void detectObjectOnBinary(NSDictionary* args, FlutterResult result) {
   int input_size;
   feedInputTensorBinary(typedData, &input_size);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -685,7 +691,7 @@ void detectObjectOnFrame(NSDictionary* args, FlutterResult result) {
   int image_channels = 4;
   feedInputTensorFrame(typedData, &input_size, image_height, image_width, image_channels, input_mean, input_std);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -714,7 +720,7 @@ void runPix2PixOnImage(NSDictionary* args, FlutterResult result) {
   int input_size;
   feedInputTensorImage(image_path, input_mean, input_std, &input_size);
 
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -751,7 +757,7 @@ void runPix2PixOnBinary(NSDictionary* args, FlutterResult result) {
   int input_size;
   feedInputTensorBinary(typedData, &input_size);
 
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -788,7 +794,7 @@ void runPix2PixOnFrame(NSDictionary* args, FlutterResult result) {
   int image_channels = 4;
   feedInputTensorFrame(typedData, &input_size, image_height, image_width, image_channels, input_mean, input_std);
 
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);

--- a/ios/Classes/TflitePlugin.mm
+++ b/ios/Classes/TflitePlugin.mm
@@ -899,15 +899,15 @@ void runSegmentationOnImage(NSDictionary* args, FlutterResult result) {
   const NSString* outputType = args[@"outputType"];
   NSMutableArray* empty = [@[] mutableCopy];
   
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
     return result(empty);
   }
   
   int input_size;
   feedInputTensorImage(image_path, input_mean, input_std, &input_size);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -925,15 +925,15 @@ void runSegmentationOnBinary(NSDictionary* args, FlutterResult result) {
   const NSString* outputType = args[@"outputType"];
   NSMutableArray* empty = [@[] mutableCopy];
   
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
     return result(empty);
   }
   
   int input_size;
   feedInputTensorBinary(typedData, &input_size);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);
@@ -954,9 +954,9 @@ void runSegmentationOnFrame(NSDictionary* args, FlutterResult result) {
   const NSArray* labelColors = args[@"labelColors"];
   const NSString* outputType = args[@"outputType"];
   NSMutableArray* empty = [@[] mutableCopy];
-  
-  if (!interpreter) {
-    NSLog(@"Failed to construct interpreter.");
+
+  if (!interpreter || interpreter_busy) {
+    NSLog(@"Failed to construct interpreter or busy.");
     return result(empty);
   }
   
@@ -964,7 +964,7 @@ void runSegmentationOnFrame(NSDictionary* args, FlutterResult result) {
   int image_channels = 4;
   feedInputTensorFrame(typedData, &input_size, image_height, image_width, image_channels, input_mean, input_std);
   
-  runTfliteAsync(^(TfLiteStatus status) {
+  runTflite(args, ^(TfLiteStatus status) {
     if (status != kTfLiteOk) {
       NSLog(@"Failed to invoke!");
       return result(empty);

--- a/ios/Classes/ios_image_load.h
+++ b/ios/Classes/ios_image_load.h
@@ -5,8 +5,7 @@ std::vector<uint8_t> LoadImageFromFile(const char* file_name,
 						 int* out_height,
 						 int* out_channels);
 
-BOOL SaveImageToFile(NSMutableData*,
-						 const char* file_name,
+NSData *CompressImage(NSMutableData*,
 						 int width,
 						 int height,
              int bytesPerPixel);

--- a/ios/Classes/ios_image_load.mm
+++ b/ios/Classes/ios_image_load.mm
@@ -72,28 +72,22 @@ std::vector<uint8_t> LoadImageFromFile(const char* file_name,
   return result;
 }
 
-BOOL SaveImageToFile(NSMutableData *image, const char* file_name, int width, int height, int bytesPerPixel) {
+NSData *CompressImage(NSMutableData *image, int width, int height, int bytesPerPixel) {
   const int channels = 4;
   CGColorSpaceRef color_space = CGColorSpaceCreateDeviceRGB();
   CGContextRef context = CGBitmapContextCreate([image mutableBytes], width, height,
                                                bytesPerPixel*8, width*channels*bytesPerPixel, color_space,
                                                kCGImageAlphaPremultipliedLast | (bytesPerPixel == 4 ? kCGBitmapFloatComponents : kCGBitmapByteOrder32Big));
   CGColorSpaceRelease(color_space);
-  if (context == nil) return NO;
+  if (context == nil) return nil;
 
   CGImageRef imgRef = CGBitmapContextCreateImage(context);
   CGContextRelease(context);
-  if (imgRef == nil) return NO;
+  if (imgRef == nil) return nil;
 
   UIImage* img = [UIImage imageWithCGImage:imgRef];
   CGImageRelease(imgRef);
-  if (img == nil) return NO;
+  if (img == nil) return nil;
 
-  NSData *data = UIImagePNGRepresentation(img);
-  if (data == nil) return NO;
-
-  FILE* file_handle = fopen(file_name, "wb");
-  BOOL ret = data.length == fwrite([data bytes], 1, data.length, file_handle);
-  fclose(file_handle);
-  return ret;
+  return UIImagePNGRepresentation(img);
 }

--- a/lib/tflite.dart
+++ b/lib/tflite.dart
@@ -189,10 +189,11 @@ class Tflite {
     return await _channel.invokeMethod('close');
   }
 
-  static Future<List> runPix2PixOnImage(
+  static Future<Uint8List> runPix2PixOnImage(
       {@required String path,
       double imageMean = 0,
       double imageStd = 255.0,
+      String outputType = "png",
       bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runPix2PixOnImage',
@@ -201,29 +202,33 @@ class Tflite {
         "imageMean": imageMean,
         "imageStd": imageStd,
         "asynch": asynch,
+        "outputType": outputType,
       },
     );
   }
 
-  static Future<List> runPix2PixOnBinary(
+  static Future<Uint8List> runPix2PixOnBinary(
       {@required Uint8List binary,
+      String outputType = "png",
       bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runPix2PixOnBinary',
       {
         "binary": binary,
         "asynch": asynch,
+        "outputType": outputType,
       },
     );
   }
 
-  static Future<List> runPix2PixOnFrame({
+  static Future<Uint8List> runPix2PixOnFrame({
     @required List<Uint8List> bytesList,
     int imageHeight = 1280,
     int imageWidth = 720,
     double imageMean = 0,
     double imageStd = 255.0,
     int rotation: 90, // Android only
+    String outputType = "png",
     bool asynch = true,
   }) async {
     return await _channel.invokeMethod(
@@ -236,6 +241,7 @@ class Tflite {
         "imageStd": imageStd,
         "rotation": rotation,
         "asynch": asynch,
+        "outputType": outputType,
       },
     );
   }

--- a/lib/tflite.dart
+++ b/lib/tflite.dart
@@ -23,7 +23,8 @@ class Tflite {
       double imageMean = 117.0,
       double imageStd = 1.0,
       int numResults = 5,
-      double threshold = 0.1}) async {
+      double threshold = 0.1,
+      bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runModelOnImage',
       {
@@ -31,7 +32,8 @@ class Tflite {
         "imageMean": imageMean,
         "imageStd": imageStd,
         "numResults": numResults,
-        "threshold": threshold
+        "threshold": threshold,
+        "asynch": asynch,
       },
     );
   }
@@ -39,10 +41,16 @@ class Tflite {
   static Future<List> runModelOnBinary(
       {@required Uint8List binary,
       int numResults = 5,
-      double threshold = 0.1}) async {
+      double threshold = 0.1,
+      bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runModelOnBinary',
-      {"binary": binary, "numResults": numResults, "threshold": threshold},
+      {
+        "binary": binary,
+        "numResults": numResults,
+        "threshold": threshold,
+        "asynch": asynch,
+      },
     );
   }
 
@@ -54,7 +62,8 @@ class Tflite {
       double imageStd = 127.5,
       int rotation: 90, // Android only
       int numResults = 5,
-      double threshold = 0.1}) async {
+      double threshold = 0.1,
+      bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runModelOnFrame',
       {
@@ -65,7 +74,8 @@ class Tflite {
         "imageStd": imageStd,
         "rotation": rotation,
         "numResults": numResults,
-        "threshold": threshold
+        "threshold": threshold,
+        "asynch": asynch,
       },
     );
   }
@@ -94,6 +104,7 @@ class Tflite {
     List anchors = anchors,
     int blockSize = 32,
     int numBoxesPerBlock = 5,
+    bool asynch = true,
   }) async {
     return await _channel.invokeMethod(
       'detectObjectOnImage',
@@ -106,7 +117,8 @@ class Tflite {
         "numResultsPerClass": numResultsPerClass,
         "anchors": anchors,
         "blockSize": blockSize,
-        "numBoxesPerBlock": numBoxesPerBlock
+        "numBoxesPerBlock": numBoxesPerBlock,
+        "asynch": asynch,
       },
     );
   }
@@ -120,6 +132,7 @@ class Tflite {
     List anchors = anchors,
     int blockSize = 32,
     int numBoxesPerBlock = 5,
+    bool asynch = true,
   }) async {
     return await _channel.invokeMethod(
       'detectObjectOnBinary',
@@ -130,7 +143,8 @@ class Tflite {
         "numResultsPerClass": numResultsPerClass,
         "anchors": anchors,
         "blockSize": blockSize,
-        "numBoxesPerBlock": numBoxesPerBlock
+        "numBoxesPerBlock": numBoxesPerBlock,
+        "asynch": asynch,
       },
     );
   }
@@ -149,6 +163,7 @@ class Tflite {
     List anchors = anchors,
     int blockSize = 32,
     int numBoxesPerBlock = 5,
+    bool asynch = true,
   }) async {
     return await _channel.invokeMethod(
       'detectObjectOnFrame',
@@ -164,7 +179,8 @@ class Tflite {
         "numResultsPerClass": numResultsPerClass,
         "anchors": anchors,
         "blockSize": blockSize,
-        "numBoxesPerBlock": numBoxesPerBlock
+        "numBoxesPerBlock": numBoxesPerBlock,
+        "asynch": asynch,
       },
     );
   }
@@ -176,21 +192,28 @@ class Tflite {
   static Future<List> runPix2PixOnImage(
       {@required String path,
       double imageMean = 0,
-      double imageStd = 255.0}) async {
+      double imageStd = 255.0,
+      bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runPix2PixOnImage',
       {
         "path": path,
         "imageMean": imageMean,
         "imageStd": imageStd,
+        "asynch": asynch,
       },
     );
   }
 
-  static Future<List> runPix2PixOnBinary({@required Uint8List binary}) async {
+  static Future<List> runPix2PixOnBinary(
+      {@required Uint8List binary,
+      bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runPix2PixOnBinary',
-      {"binary": binary},
+      {
+        "binary": binary,
+        "asynch": asynch,
+      },
     );
   }
 
@@ -201,6 +224,7 @@ class Tflite {
     double imageMean = 0,
     double imageStd = 255.0,
     int rotation: 90, // Android only
+    bool asynch = true,
   }) async {
     return await _channel.invokeMethod(
       'runPix2PixOnFrame',
@@ -211,6 +235,7 @@ class Tflite {
         "imageMean": imageMean,
         "imageStd": imageStd,
         "rotation": rotation,
+        "asynch": asynch,
       },
     );
   }
@@ -245,7 +270,8 @@ class Tflite {
       double imageMean = 0,
       double imageStd = 255.0,
       List<int> labelColors,
-      String outputType = "png"}) async {
+      String outputType = "png",
+      bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runSegmentationOnImage',
       {
@@ -254,6 +280,7 @@ class Tflite {
         "imageStd": imageStd,
         "labelColors": labelColors ?? pascalVOCLabelColors,
         "outputType": outputType,
+        "asynch": asynch,
       },
     );
   }
@@ -261,13 +288,15 @@ class Tflite {
   static Future<Uint8List> runSegmentationOnBinary(
       {@required Uint8List binary,
       List<int> labelColors,
-      String outputType = "png"}) async {
+      String outputType = "png",
+      bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runSegmentationOnImage',
       {
         "binary": binary,
         "labelColors": labelColors ?? pascalVOCLabelColors,
         "outputType": outputType,
+        "asynch": asynch,
       },
     );
   }
@@ -280,7 +309,8 @@ class Tflite {
       double imageStd = 255.0,
       int rotation: 90, // Android only
       List<int> labelColors,
-      String outputType = "png"}) async {
+      String outputType = "png",
+      bool asynch = true}) async {
     return await _channel.invokeMethod(
       'runSegmentationOnImage',
       {
@@ -292,6 +322,7 @@ class Tflite {
         "rotation": rotation,
         "labelColors": labelColors ?? pascalVOCLabelColors,
         "outputType": outputType,
+        "asynch": asynch,
       },
     );
   }

--- a/lib/tflite.dart
+++ b/lib/tflite.dart
@@ -187,21 +187,21 @@ class Tflite {
     );
   }
 
-  static Future<List> runPix2PixOnBinary(
-      {@required Uint8List binary}) async {
+  static Future<List> runPix2PixOnBinary({@required Uint8List binary}) async {
     return await _channel.invokeMethod(
-      'runPix2PixOnBinary', {"binary": binary},
+      'runPix2PixOnBinary',
+      {"binary": binary},
     );
   }
 
-  static Future<List> runPix2PixOnFrame(
-      {@required List<Uint8List> bytesList,
-      int imageHeight = 1280,
-      int imageWidth = 720,
-      double imageMean = 0,
-      double imageStd = 255.0,
-      int rotation: 90, // Android only
-      }) async {
+  static Future<List> runPix2PixOnFrame({
+    @required List<Uint8List> bytesList,
+    int imageHeight = 1280,
+    int imageWidth = 720,
+    double imageMean = 0,
+    double imageStd = 255.0,
+    int rotation: 90, // Android only
+  }) async {
     return await _channel.invokeMethod(
       'runPix2PixOnFrame',
       {
@@ -217,43 +217,82 @@ class Tflite {
 
   // https://github.com/meetshah1995/pytorch-semseg/blob/master/ptsemseg/loader/pascal_voc_loader.py
   static List<int> pascalVOCLabelColors = [
-    Color.fromARGB(255,   0,   0,   0).value, // background
-    Color.fromARGB(255, 128,   0,   0).value, // aeroplane
-    Color.fromARGB(255,   0, 128,   0).value, // biyclce
-    Color.fromARGB(255, 128, 128,   0).value, // bird
-    Color.fromARGB(255,   0,   0, 128).value, // boat
-    Color.fromARGB(255, 128,   0, 128).value, // bottle
-    Color.fromARGB(255,   0, 128, 128).value, // bus
+    Color.fromARGB(255, 0, 0, 0).value, // background
+    Color.fromARGB(255, 128, 0, 0).value, // aeroplane
+    Color.fromARGB(255, 0, 128, 0).value, // biyclce
+    Color.fromARGB(255, 128, 128, 0).value, // bird
+    Color.fromARGB(255, 0, 0, 128).value, // boat
+    Color.fromARGB(255, 128, 0, 128).value, // bottle
+    Color.fromARGB(255, 0, 128, 128).value, // bus
     Color.fromARGB(255, 128, 128, 128).value, // car
-    Color.fromARGB(255,  64,   0,   0).value, // cat
-    Color.fromARGB(255, 192,   0,   0).value, // chair
-    Color.fromARGB(255,  64, 128,   0).value, // cow
-    Color.fromARGB(255, 192, 128,   0).value, // diningtable
-    Color.fromARGB(255,  64,   0, 128).value, // dog
-    Color.fromARGB(255, 192,   0, 128).value, // horse
-    Color.fromARGB(255, 64,  128, 128).value, // motorbike
+    Color.fromARGB(255, 64, 0, 0).value, // cat
+    Color.fromARGB(255, 192, 0, 0).value, // chair
+    Color.fromARGB(255, 64, 128, 0).value, // cow
+    Color.fromARGB(255, 192, 128, 0).value, // diningtable
+    Color.fromARGB(255, 64, 0, 128).value, // dog
+    Color.fromARGB(255, 192, 0, 128).value, // horse
+    Color.fromARGB(255, 64, 128, 128).value, // motorbike
     Color.fromARGB(255, 192, 128, 128).value, // person
-    Color.fromARGB(255,   0,  64,   0).value, // potted plant
-    Color.fromARGB(255, 128,  64,   0).value, // sheep
-    Color.fromARGB(255,   0, 192,   0).value, // sofa
-    Color.fromARGB(255, 128, 192,   0).value, // train
-    Color.fromARGB(255,   0,  64, 128).value, // tv-monitor
+    Color.fromARGB(255, 0, 64, 0).value, // potted plant
+    Color.fromARGB(255, 128, 64, 0).value, // sheep
+    Color.fromARGB(255, 0, 192, 0).value, // sofa
+    Color.fromARGB(255, 128, 192, 0).value, // train
+    Color.fromARGB(255, 0, 64, 128).value, // tv-monitor
   ];
 
   static Future<Uint8List> runSegmentationOnImage(
       {@required String path,
-        double imageMean = 0,
-        double imageStd = 255.0}) async {
+      double imageMean = 0,
+      double imageStd = 255.0,
+      List<int> labelColors,
+      String outputType = "png"}) async {
     return await _channel.invokeMethod(
       'runSegmentationOnImage',
       {
         "path": path,
         "imageMean": imageMean,
         "imageStd": imageStd,
-        "labelColors": pascalVOCLabelColors,
+        "labelColors": labelColors ?? pascalVOCLabelColors,
+        "outputType": outputType,
+      },
+    );
+  }
+
+  static Future<Uint8List> runSegmentationOnBinary(
+      {@required Uint8List binary,
+      List<int> labelColors,
+      String outputType = "png"}) async {
+    return await _channel.invokeMethod(
+      'runSegmentationOnImage',
+      {
+        "binary": binary,
+        "labelColors": labelColors ?? pascalVOCLabelColors,
+        "outputType": outputType,
+      },
+    );
+  }
+
+  static Future<Uint8List> runSegmentationOnFrame(
+      {@required List<Uint8List> bytesList,
+      int imageHeight = 1280,
+      int imageWidth = 720,
+      double imageMean = 0,
+      double imageStd = 255.0,
+      int rotation: 90, // Android only
+      List<int> labelColors,
+      String outputType = "png"}) async {
+    return await _channel.invokeMethod(
+      'runSegmentationOnImage',
+      {
+        "bytesList": bytesList,
+        "imageHeight": imageHeight,
+        "imageWidth": imageWidth,
+        "imageMean": imageMean,
+        "imageStd": imageStd,
+        "rotation": rotation,
+        "labelColors": labelColors ?? pascalVOCLabelColors,
+        "outputType": outputType,
       },
     );
   }
 }
-
-


### PR DESCRIPTION
The diff should be examined via command line "git diff -w" to ignore whitespace.

I found these changes necessary running pix2pix GANs because iOS will kill your process (looks just like a crash) if you block the UI thread for more than a couple seconds.

These changes also allow CircularProgressIndicator to spin while TfLite runs.

Because the versatility of TfLite I left the option to run the processing on the UI thread by passing asynch: false.

I realize this is a big change, with choices as to API variable names, and others.  Let me know what you think!  Thanks.

