### PR TITLE
#47 Example fix

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -71,12 +71,12 @@ class _MyAppState extends State<MyApp> {
 
     new FileImage(image)
         .resolve(new ImageConfiguration())
-        .addListener((ImageInfo info, bool _) {
+        .addListener(ImageStreamListener((ImageInfo info, bool _) {
       setState(() {
         _imageHeight = info.image.height.toDouble();
         _imageWidth = info.image.width.toDouble();
       });
-    });
+    }));
 
     setState(() {
       _image = image;
@@ -87,6 +87,14 @@ class _MyAppState extends State<MyApp> {
   @override
   void initState() {
     super.initState();
+
+    _busy = true;
+
+    loadModel().then((val) {
+      setState(() {
+        _busy = false; 
+      });
+    });
   }
 
   Future loadModel() async {


### PR DESCRIPTION
When starting the application with an example, an error occurs if you immediately select a picture for recognition. This is due to the fact that the model for which recognition will occur has not yet been selected. In this PR we can see the fix for this error.

This PR can be linked to Issue #47