### PR TITLE
fix(ios, build): pin TensorFlowLiteC to 2.2.0 to fix compile

### DIFF
--- a/ios/tflite.podspec
+++ b/ios/tflite.podspec
@@ -15,7 +15,7 @@ A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TensorFlowLiteC'
+  s.dependency 'TensorFlowLiteC', '~> 2.2.0'
   s.xcconfig = { 'USER_HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/tflite" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Flutter" "${PODS_ROOT}/Headers/Public/TensorFlowLite/tensorflow_lite" "${PODS_ROOT}/Headers/Public/tflite" "${PODS_ROOT}/TensorFlowLite/Frameworks/tensorflow_lite.framework/Headers" "${PODS_ROOT}/TensorFlowLiteC/Frameworks/TensorFlowLiteC.framework/Headers"' }
 
   s.ios.deployment_target = '9.0'


### PR DESCRIPTION
In 2.3.0 and higher, the Metal / GPU component is split off
An alternative would be to add a dependency to TensorFlowLiteC/Metal
Fixes #139