### PR TITLE
The plugin `tflite_maven` uses a deprecated version of the Android embedding.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# tflite
+# tflite_maven
+A fork of [tflite](https://pub.dev/packages/tflite)
+
 
 A Flutter plugin for accessing TensorFlow Lite API. Supports image classification, object detection ([SSD](https://github.com/tensorflow/models/tree/master/research/object_detection) and [YOLO](https://pjreddie.com/darknet/yolov2/)), [Pix2Pix](https://phillipi.github.io/pix2pix/) and [Deeplab](https://github.com/tensorflow/models/tree/master/research/deeplab) and [PoseNet](https://www.tensorflow.org/lite/models/pose_estimation/overview) on both iOS and Android.
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -4,7 +4,7 @@ version '1.0-SNAPSHOT'
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {
@@ -15,7 +15,7 @@ buildscript {
 rootProject.allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -3,14 +3,14 @@ PODS:
   - image_picker (0.0.1):
     - Flutter
   - TensorFlowLiteC (2.2.0)
-  - tflite (1.1.2):
+  - tflite_maven (1.1.4):
     - Flutter
     - TensorFlowLiteC
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
   - image_picker (from `.symlinks/plugins/image_picker/ios`)
-  - tflite (from `.symlinks/plugins/tflite/ios`)
+  - tflite_maven (from `.symlinks/plugins/tflite_maven/ios`)
 
 SPEC REPOS:
   trunk:
@@ -21,15 +21,15 @@ EXTERNAL SOURCES:
     :path: Flutter
   image_picker:
     :path: ".symlinks/plugins/image_picker/ios"
-  tflite:
-    :path: ".symlinks/plugins/tflite/ios"
+  tflite_maven:
+    :path: ".symlinks/plugins/tflite_maven/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
-  image_picker: a211f28b95a560433c00f5cd3773f4710a20404d
+  Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
+  image_picker: 9aa50e1d8cdacdbed739e925b7eea16d014367e6
   TensorFlowLiteC: b3ab9e867b0b71052ca102a32a786555b330b02e
-  tflite: f0403a894740019d63ab5662253bba5b2dd37296
+  tflite_maven: fcf91aaf81dfccdbb8dfb454c92f7671022936b0
 
 PODFILE CHECKSUM: 8e679eca47255a8ca8067c4c67aab20e64cb974d
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.11.2

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -5,7 +5,7 @@ PODS:
   - TensorFlowLiteC (2.2.0)
   - tflite_maven (1.1.4):
     - Flutter
-    - TensorFlowLiteC
+    - TensorFlowLiteC (= 2.2.0)
 
 DEPENDENCIES:
   - Flutter (from `Flutter`)
@@ -28,7 +28,7 @@ SPEC CHECKSUMS:
   Flutter: 50d75fe2f02b26cc09d224853bb45737f8b3214a
   image_picker: 9aa50e1d8cdacdbed739e925b7eea16d014367e6
   TensorFlowLiteC: b3ab9e867b0b71052ca102a32a786555b330b02e
-  tflite_maven: fcf91aaf81dfccdbb8dfb454c92f7671022936b0
+  tflite_maven: 85beee7851156235d7914b341bbf6b1ad9d29ff6
 
 PODFILE CHECKSUM: 8e679eca47255a8ca8067c4c67aab20e64cb974d
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:image/image.dart' as img;
 
-import 'package:tflite/tflite.dart';
+import 'package:tflite_maven/tflite.dart';
 import 'package:image_picker/image_picker.dart';
 
 void main() => runApp(new App());
@@ -40,12 +40,13 @@ class _MyAppState extends State<MyApp> {
   bool _busy = false;
 
   Future predictImagePicker() async {
-    var image = await ImagePicker.pickImage(source: ImageSource.gallery);
+    final ImagePicker _picker = ImagePicker();
+    var image = await _picker.pickImage(source: ImageSource.gallery);
     if (image == null) return;
     setState(() {
       _busy = true;
     });
-    predictImage(image);
+    predictImage(File(image.path));
   }
 
   Future predictImage(File image) async {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -24,11 +24,11 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  image_picker: ^0.6.7
+  image_picker: ^0.8.4+4
   
-  image: ^2.1.4
+  image: ^3.1.0
 
-  tflite:
+  tflite_maven:
     path: ../
 
   test: ^1.12.0

--- a/ios/tflite_maven.podspec
+++ b/ios/tflite_maven.podspec
@@ -2,8 +2,8 @@
 # To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
 #
 Pod::Spec.new do |s|
-  s.name             = 'tflite'
-  s.version          = '1.1.2'
+  s.name             = 'tflite_maven'
+  s.version          = '1.1.4'
   s.summary          = 'A Flutter plugin for accessing TensorFlow Lite.'
   s.description      = <<-DESC
 A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.

--- a/ios/tflite_maven.podspec
+++ b/ios/tflite_maven.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'tflite_maven'
-  s.version          = '1.1.4'
+  s.version          = '1.1.5'
   s.summary          = 'A Flutter plugin for accessing TensorFlow Lite.'
   s.description      = <<-DESC
 A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.
@@ -15,7 +15,7 @@ A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'TensorFlowLiteC'
+  s.dependency 'TensorFlowLiteC', "2.2.0"
   s.xcconfig = { 'USER_HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/tflite" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Flutter" "${PODS_ROOT}/Headers/Public/TensorFlowLite/tensorflow_lite" "${PODS_ROOT}/Headers/Public/tflite" "${PODS_ROOT}/TensorFlowLite/Frameworks/tensorflow_lite.framework/Headers" "${PODS_ROOT}/TensorFlowLiteC/Frameworks/TensorFlowLiteC.framework/Headers"' }
 
   s.ios.deployment_target = '9.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
-name: tflite
+name: tflite_maven
 description: A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.
 version: 1.1.2
-homepage: https://github.com/shaqian/flutter_tflite
+homepage: https://github.com/earvinjake/flutter_tflite
 
 environment:
   sdk: '>=2.12.0 <3.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tflite_maven
 description: A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.
-version: 1.1.3
+version: 1.1.4
 homepage: https://github.com/earvinjake/flutter_tflite
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tflite_maven
 description: A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.
-version: 1.1.4
+version: 1.1.5
 homepage: https://github.com/earvinjake/flutter_tflite
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: tflite_maven
 description: A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.
-version: 1.1.2
+version: 1.1.3
 homepage: https://github.com/earvinjake/flutter_tflite
 
 environment:

--- a/test/tflite_test.dart
+++ b/test/tflite_test.dart
@@ -2,7 +2,7 @@ import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:tflite/tflite.dart';
+import 'package:tflite_maven/tflite.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();


### PR DESCRIPTION
I tried to use this plugin but I got a warning while pub get

The plugin `tflite_maven` uses a deprecated version of the Android embedding.
To avoid unexpected runtime failures, or future build failures, try to see if this plugin supports the Android V2 embedding. Otherwise, consider removing it since a future release of Flutter will remove these deprecated APIs.
If you are plugin author, take a look at the docs for migrating the plugin to the V2 embedding: https://flutter.dev/go/android-plugin-migration.

Will there the any issue?