### PR TITLE
Fix "metal_delegate.h" missing file error on iOS for TFlite 2.3.0+

### DIFF
--- a/ios/tflite.podspec
+++ b/ios/tflite.podspec
@@ -16,8 +16,9 @@ A Flutter plugin for accessing TensorFlow Lite. Supports both iOS and Android.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'TensorFlowLiteC'
-  s.xcconfig = { 'USER_HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/tflite" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Flutter" "${PODS_ROOT}/Headers/Public/TensorFlowLite/tensorflow_lite" "${PODS_ROOT}/Headers/Public/tflite" "${PODS_ROOT}/TensorFlowLite/Frameworks/tensorflow_lite.framework/Headers" "${PODS_ROOT}/TensorFlowLiteC/Frameworks/TensorFlowLiteC.framework/Headers"' }
-
+  s.dependency 'TensorFlowLiteC/Metal'
+  s.xcconfig = { 'USER_HEADER_SEARCH_PATHS' => '$(inherited) "${PODS_ROOT}/Headers/Private" "${PODS_ROOT}/Headers/Private/tflite" "${PODS_ROOT}/Headers/Public" "${PODS_ROOT}/Headers/Public/Flutter" "${PODS_ROOT}/Headers/Public/TensorFlowLite/tensorflow_lite" "${PODS_ROOT}/Headers/Public/tflite" "${PODS_ROOT}/TensorFlowLite/Frameworks/tensorflow_lite.framework/Headers"  "${PODS_ROOT}/TensorFlowLiteC/Frameworks/TensorFlowLiteC.framework/Headers"  "${PODS_ROOT}/TensorFlowLiteC/Frameworks/TensorFlowLiteCMetal.framework/Headers"' }
+  
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 end


### PR DESCRIPTION
Add explicit reference to iOS metal headers